### PR TITLE
Added File Content Detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _workspace
 *.swp
 talisman
+.idea/**

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -38,6 +38,18 @@ func TestAddingSecretKeyShouldExitOne(t *testing.T) {
 	})
 }
 
+func TestAddingSecretKeyAsFileContentShouldExitOne(t *testing.T) {
+	const awsAccessKeyIDExample string = "accessKey=AKIAIOSFODNN7EXAMPLE"
+	withNewTmpGitRepo(func(gitPath string) {
+		git.SetupBaselineFiles(gitPath, "simple-file")
+		git.CreateFileWithContents(gitPath, "contains_keys.properties", awsAccessKeyIDExample)
+		git.AddAndcommit(gitPath, "*", "add private key as content")
+
+		exitStatus := runTalisman(gitPath)
+		assert.Equal(t, 1, exitStatus, "Expected run() to return 1 and fail as pem file was present in the repo")
+	})
+}
+
 func TestAddingSecretKeyShouldExitZeroIfPEMFilesAreIgnored(t *testing.T) {
 	withNewTmpGitRepo(func(gitPath string) {
 		git.SetupBaselineFiles(gitPath, "simple-file")

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -26,6 +26,7 @@ func NewChain() *Chain {
 func DefaultChain() *Chain {
 	result := NewChain()
 	result.AddDetector(DefaultFileNameDetector())
+	result.AddDetector(NewFileContentDetector())
 	return result
 }
 

--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -1,0 +1,58 @@
+package detector
+
+import (
+	"encoding/base64"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/thoughtworks/talisman/git_repo"
+	"strings"
+)
+
+var delimiters = []string{".", "-", "="}
+
+type FileContentDetector struct {
+}
+
+func NewFileContentDetector() Detector {
+	return FileContentDetector{}
+}
+
+func (contentDetector FileContentDetector) Test(additions []git_repo.Addition, ignores Ignores, result *DetectionResults) {
+	for _, addition := range additions {
+		if ignores.Deny(addition) {
+			log.WithFields(log.Fields{
+				"filePath": addition.Path,
+			}).Info("Ignoring addition as it was specified to be ignored.")
+			result.Ignore(addition.Path, fmt.Sprintf("%s was ignored by .talismanignore", addition.Path))
+			continue
+		}
+		base64 := checkBase64EncodingForFile(addition.Data)
+		if base64 == true {
+			log.WithFields(log.Fields{
+				"filePath": addition.Path,
+			}).Info("Failing file as it contains a base64 encoded text.")
+			result.Fail(addition.Path, fmt.Sprint("Expected file to not to contain base64 encoded texts"))
+		}
+	}
+}
+
+func checkBase64Encoding(s string) bool {
+	if len(s) <= 4 {
+		return false
+	}
+	_, err := base64.StdEncoding.DecodeString(s)
+	return err == nil
+}
+
+func checkBase64EncodingForFile(content []byte) bool {
+	s := string(content)
+	for _, d := range delimiters {
+		subStrings := strings.Split(s, d)
+		for _, sub := range subStrings {
+			if checkBase64Encoding(sub) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -48,10 +48,17 @@ func checkBase64EncodingForFile(content []byte) bool {
 	s := string(content)
 	for _, d := range delimiters {
 		subStrings := strings.Split(s, d)
-		for _, sub := range subStrings {
-			if checkBase64Encoding(sub) {
-				return true
-			}
+		if checkEachSubString(subStrings) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkEachSubString(subStrings []string) bool {
+	for _, sub := range subStrings {
+		if checkBase64Encoding(sub) {
+			return true
 		}
 	}
 	return false

--- a/detector/filecontent_detector_test.go
+++ b/detector/filecontent_detector_test.go
@@ -1,0 +1,76 @@
+package detector
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/thoughtworks/talisman/git_repo"
+	"testing"
+)
+
+func TestShouldNotFlagSafeText(t *testing.T) {
+	results := NewDetectionResults()
+	content := []byte("prettySafe")
+	filename := "filename"
+	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
+
+	NewFileContentDetector().Test(additions, NewIgnores(), results)
+	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+}
+
+func TestShouldFlagPotentialAWSAccessKeys(t *testing.T) {
+	const awsAccessKeyIDExample string = "AKIAIOSFODNN7EXAMPLE"
+	results := NewDetectionResults()
+	content := []byte(awsAccessKeyIDExample)
+	filename := "filename"
+	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
+
+	NewFileContentDetector().Test(additions, NewIgnores(), results)
+	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+}
+
+func TestShouldFlagPotentialAWSAccessKeysInPropertyDefinition(t *testing.T) {
+	const awsAccessKeyIDExample string = "accessKey=AKIAIOSFODNN7EXAMPLE"
+	results := NewDetectionResults()
+	content := []byte(awsAccessKeyIDExample)
+	filename := "filename"
+	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
+
+	NewFileContentDetector().Test(additions, NewIgnores(), results)
+	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+}
+
+func TestShouldNotFlag4CharSafeText(t *testing.T) {
+	/*This only tell that an input could have been a b64 encoded value, but it does not tell whether or not the
+	input is actually a b64 encoded value. In other words, abcd will match, but it is not necessarily represent
+	 the encoded value of i· rather just a plain abcd input
+	 see stackoverflow.com/questions/8571501/how-to-check-whether-the-string-is-base64-encoded-or-not#comment23919648_8571649*/
+	results := NewDetectionResults()
+	content := []byte("abcd")
+	filename := "filename"
+	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
+
+	NewFileContentDetector().Test(additions, NewIgnores(), results)
+	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+}
+
+func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
+	const awsSecretAccessKey string = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	results := NewDetectionResults()
+	content := []byte(awsSecretAccessKey)
+	filename := "filename"
+	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
+
+	NewFileContentDetector().Test(additions, NewIgnores(), results)
+	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+
+}
+
+func TestShouldFlagPotentialJWT(t *testing.T) {
+	const jwt string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUiOiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f757"
+	results := NewDetectionResults()
+	content := []byte(jwt)
+	filename := "filename"
+	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
+
+	NewFileContentDetector().Test(additions, NewIgnores(), results)
+	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+}


### PR DESCRIPTION
Adds a detector that aimed to scan file content to be able to detect if a file that contains a secret key or a token. It does this basically trying to decode content regarding base64 encoding. If it finds a base64 encoded text like AWS Access Key or JWT Token it is going to log it as error.

Sample keys fetched from [AWS docs](https://aws.amazon.com/developers/access-keys/).   