### PR TITLE
[Pre Push Hook] Validating new repositories by providing default empty tree SHA

### DIFF
--- a/.talismanignore
+++ b/.talismanignore
@@ -1,1 +1,2 @@
 install.sh
+pre_push_hook.go


### PR DESCRIPTION
`4b825dc642cb6eb9a060e54bf8d69288fbee4904` is the SHA of the `empty tree` in Git and it's always available in every repository. I used the above SHA to validate the new repositories.