### PR TITLE
Add acceptance test to talismanignore 

### DIFF
--- a/.talismanignore
+++ b/.talismanignore
@@ -1,2 +1,3 @@
 install.sh
 pre_push_hook.go
+acceptance_test.go


### PR DESCRIPTION
`acceptance_test.go` contains a key for test purposes so it should probably be ignored: 

```
The following errors were detected in acceptance_test.go
	 Expected file to not to contain base64 or hex encoded texts such as: "accessKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`
```