### PR TITLE
Add --pattern argument to allow glob-like matching of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,12 @@ ideally, code that implements your ideas and suggestions!
 
 ## Installation
 
-Talisman can either be installed into a single git repository, or as a global
-[git hook template](https://git-scm.com/docs/git-init#_template_directory).
+Talisman can either be installed and used in three different ways 
+1. As a git hook into a single git repository
+2. As a git hook as a global [git hook template](https://git-scm.com/docs/git-init#_template_directory)
+3. As a CLI with the `--pattern` argument to find files
 
-Talisman can be set up a as a pre-push or pre-commit hook on git repositories.
-
-
-### Installation as a global hook template (recommended)
-We recommend installing it as a git hook template, as that will cause
-Talisman to be present, not only in your existing git repositories, but also in any new repository that you 'init' or
-'clone'.
-
-Use the [Global scripts Readme](global_install_scripts/Readme.md) to guide you through the installation process.
+As a git hook, Talisman can be set up a as a pre-push or pre-commit hook on git repositories.
 
 ### Installation to a single project
 
@@ -46,6 +40,25 @@ chmod +x ~/install-talisman.sh
 cd my-git-project
 ~/install-talisman.sh
 ```
+
+### Installation as a CLI
+
+1. Download the Talisman binary from the [Releases page](https://github.com/thoughtworks/talisman/releases) corresponding to your system type
+2. Place the binary somewhere (either directly in your repository, or by putting it somewhere in your system and adding it to your `$PATH`)
+3. Run talisman with the `--pattern` argument (matches glob-like patterns, [see more](https://github.com/bmatcuk/doublestar#patterns))
+```bash
+# finds all .go and .md files in the current directory (recursively) 
+talisman --pattern="./**/*.{go,md}"
+```
+
+### Installation as a global hook template (recommended)
+We recommend installing it as a git hook template, as that will cause
+Talisman to be present, not only in your existing git repositories, but also in any new repository that you 'init' or
+'clone'.
+
+Use the [Global scripts Readme](global_install_scripts/Readme.md) to guide you through the installation process.
+
+### Installation 
 
 #### Usage with the [pre-commit](https://pre-commit.com) git hooks framework
 

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -104,6 +104,48 @@ func TestStagingSecretKeyShouldExitOneWhenPreCommitFlagIsSet(t *testing.T) {
 	})
 }
 
+func TestPatternFindsSecretKey(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		_options := options{
+			debug:   false,
+			pattern: "./*.*",
+		}
+
+		git.SetupBaselineFiles("simple-file")
+		git.CreateFileWithContents("private.pem", "secret")
+
+		assert.Equal(t, 1, runTalismanWithOptions(git, _options), "Expected run() to return 1 and fail as pem file was present in the repo")
+	})
+}
+
+func TestPatternFindsNestedSecretKey(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		_options := options{
+			debug:   false,
+			pattern: "./**/*.*",
+		}
+
+		git.SetupBaselineFiles("simple-file")
+		git.CreateFileWithContents("some-dir/private.pem", "secret")
+
+		assert.Equal(t, 1, runTalismanWithOptions(git, _options), "Expected run() to return 1 and fail as nested pem file was present in the repo")
+	})
+}
+
+func TestPatternFindsSecretInNestedFile(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		_options := options{
+			debug:   false,
+			pattern: "./**/*.*",
+		}
+
+		git.SetupBaselineFiles("simple-file")
+		git.CreateFileWithContents("some-dir/some-file.txt", awsAccessKeyIDExample)
+
+		assert.Equal(t, 1, runTalismanWithOptions(git, _options), "Expected run() to return 1 and fail as nested pem file was present in the repo")
+	})
+}
+
 func runTalisman(git *git_testing.GitTesting) int {
 	_options := options{
 		debug:   false,

--- a/directory_hook.go
+++ b/directory_hook.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"io/ioutil"
+	"talisman/git_repo"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/bmatcuk/doublestar"
+)
+
+type DirectoryHook struct{}
+
+func NewDirectoryHook() *DirectoryHook {
+	return &DirectoryHook{}
+}
+
+func (p *DirectoryHook) GetFilesFromDirectory(globPattern string) []git_repo.Addition {
+	var result []git_repo.Addition
+
+	files, _ := doublestar.Glob(globPattern)
+	for _, file := range files {
+		data, err := ReadFile(file)
+
+		if err != nil {
+			continue
+		}
+
+		newAddition := git_repo.NewAddition(file, data)
+		result = append(result, newAddition)
+	}
+
+	return result
+}
+
+func ReadFile(filepath string) ([]byte, error) {
+	log.Debugf("reading file %s", filepath)
+	return ioutil.ReadFile(filepath)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module talisman
 
 require (
 	github.com/Sirupsen/logrus v0.0.0-20151204141443-446d1c146faa
+	github.com/bmatcuk/doublestar v1.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/drhodes/golorem v0.0.0-20120624033213-6e38d8d5e455
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Sirupsen/logrus v0.0.0-20151204141443-446d1c146faa h1:Yt7X+jyl7iyieH6aiMRd9gCaUT7Rw+wTKlzUVjjeaQ4=
 github.com/Sirupsen/logrus v0.0.0-20151204141443-446d1c146faa/go.mod h1:rmk17hk6i8ZSAJkSDa7nOxamrG+SP4P0mm+DAvExv4U=
+github.com/bmatcuk/doublestar v1.1.1 h1:YroD6BJCZBYx06yYFEWvUuKVWQn3vLLQAVmDmvTSaiQ=
+github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/drhodes/golorem v0.0.0-20120624033213-6e38d8d5e455 h1:WqCK3j5a2lJAQS/IMCLSLahINAQyI0P/RLp8WdEVR/M=


### PR DESCRIPTION
Adds a --pattern argument to allow Talisman to accept files (ala test runners detecting tests using a pattern)

eg. 
```bash
talisman --pattern="./**/*.{ts,tsx}"
```

This CLI support will be the first step in allowing Talisman to be used to:
- Scan any arbitraty codebase
- Scan non-Git codebases

Glob functionality is by [doublestar](https://github.com/bmatcuk/doublestar)

I'll need advice as to how to properly document this new 'feature' in the README (not quite sure where to put it). Comments are welcome 👍 


