### PR TITLE
Fixes talisman path for git hook in uninstall script

### DIFF
--- a/global_install_scripts/uninstall.bash
+++ b/global_install_scripts/uninstall.bash
@@ -78,8 +78,9 @@ function run() {
 	fi
 	EXCEPTIONS_FILE=${TEMP_DIR}/repos_with_multiple_hooks.paths
 	touch ${EXCEPTIONS_FILE}
-	
-	CMD_STRING="${SUDO_PREFIX} ${SEARCH_CMD} ${SEARCH_ROOT} ${EXTRA_SEARCH_OPTS} -name .git -type d -exec ${DELETE_REPO_HOOK_SCRIPT} ${TALISMAN_SETUP_DIR} ${EXCEPTIONS_FILE} {} ${HOOK_SCRIPT} \;"
+
+	TALISMAN_PATH=${TALISMAN_SETUP_DIR}/talisman_hook_script
+	CMD_STRING="${SUDO_PREFIX} ${SEARCH_CMD} ${SEARCH_ROOT} ${EXTRA_SEARCH_OPTS} -name .git -type d -exec ${DELETE_REPO_HOOK_SCRIPT} ${TALISMAN_PATH} ${EXCEPTIONS_FILE} {} ${HOOK_SCRIPT} \;"
 	echo_debug "EXECUTING: ${CMD_STRING}"
 	eval "${CMD_STRING}"
 		


### PR DESCRIPTION
The uninstall script was missing the correct path to the symlink for talisman hook causing the unistall to not work.