### PR TITLE
Fixed uninstall and install scripts for macOS Mojave users

### DIFF
--- a/global_install_scripts/install.bash
+++ b/global_install_scripts/install.bash
@@ -297,8 +297,8 @@ function run() {
 
 	CMD_STRING="${SUDO_PREFIX} ${SEARCH_CMD} ${SEARCH_ROOT} ${EXTRA_SEARCH_OPTS} -name .git -type d -exec ${REPO_HOOK_SETUP_SCRIPT_PATH} ${TALISMAN_HOOK_SCRIPT_PATH} ${EXCEPTIONS_FILE} {} \;"
 	echo_debug "EXECUTING: ${CMD_STRING}"
-	eval "${CMD_STRING}"
-	
+	eval "${CMD_STRING}" || true
+
 	NUMBER_OF_EXCEPTION_REPOS=`cat ${EXCEPTIONS_FILE} | wc -l`
 
 	OS=$(uname -s)

--- a/global_install_scripts/uninstall.bash
+++ b/global_install_scripts/uninstall.bash
@@ -82,8 +82,8 @@ function run() {
 	TALISMAN_PATH=${TALISMAN_SETUP_DIR}/talisman_hook_script
 	CMD_STRING="${SUDO_PREFIX} ${SEARCH_CMD} ${SEARCH_ROOT} ${EXTRA_SEARCH_OPTS} -name .git -type d -exec ${DELETE_REPO_HOOK_SCRIPT} ${TALISMAN_PATH} ${EXCEPTIONS_FILE} {} ${HOOK_SCRIPT} \;"
 	echo_debug "EXECUTING: ${CMD_STRING}"
-	eval "${CMD_STRING}"
-		
+	eval "${CMD_STRING}" || true
+
 	NUMBER_OF_EXCEPTION_REPOS=`cat ${EXCEPTIONS_FILE} | wc -l`
 
 	if [ ${NUMBER_OF_EXCEPTION_REPOS} -gt 0 ]; then
@@ -105,7 +105,7 @@ function run() {
     if [[ -n $TEMPLATE_DIR && -e ${TEMPLATE_DIR}/hooks/${HOOK_SCRIPT} && \
 	      ${TALISMAN_SETUP_DIR}/talisman_hook_script -ef ${TEMPLATE_DIR}/hooks/${HOOK_SCRIPT} ]]; then
 	rm -f "${TEMPLATE_DIR}/hooks/${HOOK_SCRIPT}" && \
-	    echo_success "Removed ${HOOK_SCRIPT} from ${TEMPLATE_DIR}"  
+	    echo_success "Removed ${HOOK_SCRIPT} from ${TEMPLATE_DIR}"
     fi
 
     echo_debug "Removing talisman from $TALISMAN_SETUP_DIR"


### PR DESCRIPTION
Due to permission changes for Terminal, Talisman is unable to access various folders present in the Home directory of the user. Due to this, the uninstall script ends abruptly without removing the global hook or the talisman binary.