### PR TITLE
Fixes failing test case and adds update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@ Talisman is a tool that installs a hook to your repository to ensure that potent
 It validates the outgoing changeset for things that look suspicious - such as potential SSH
 keys, authorization tokens, private keys etc.
 
-#Upgrading
-To update Talisman to the latest release, run the following curl command:
-```bash
-curl --silent  https://raw.githubusercontent.com/thoughtworks/talisman/master/global_install_scripts/update_talisman.bash > /tmp/update_talisman.bash && /bin/bash /tmp/update_talisman.bash
-```
 # Installation
 
 Talisman supports MAC OSX, Linux and Windows.
@@ -190,6 +185,11 @@ a real git revision!)
 ```bash
 # finds all .go and .md files in the current directory (recursively) 
 talisman --pattern="./**/*.{go,md}"
+```
+# Upgrading
+To update Talisman to the latest release, run the following curl command:
+```bash
+curl --silent  https://raw.githubusercontent.com/thoughtworks/talisman/master/global_install_scripts/update_talisman.bash > /tmp/update_talisman.bash && /bin/bash /tmp/update_talisman.bash
 ```
 
 # Talisman in action

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 	- [As a global hook template (Recommended)](#installation-as-a-global-hook-template)
 	- [To a single repository](#installation-to-a-single-project)
 	- [As a CLI to find file types](#installation-as-a-cli)
+- [Upgrading Talisman](#Upgrading)
 - [Talisman in action](#talisman-in-action)
 	- [Validations](#validations) 
 	- [Ignoring files](#ignoring-files)
@@ -30,7 +31,11 @@ Talisman is a tool that installs a hook to your repository to ensure that potent
 It validates the outgoing changeset for things that look suspicious - such as potential SSH
 keys, authorization tokens, private keys etc.
 
-
+#Upgrading
+To update Talisman to the latest release, run the following curl command:
+```bash
+curl --silent  https://raw.githubusercontent.com/thoughtworks/talisman/master/global_install_scripts/update_talisman.bash > /tmp/update_talisman.bash && /bin/bash /tmp/update_talisman.bash
+```
 # Installation
 
 Talisman supports MAC OSX, Linux and Windows.

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -182,7 +182,7 @@ func TestPatternFindsSecretInNestedFile(t *testing.T) {
 func runTalisman(git *git_testing.GitTesting) int {
 	_options := options{
 		debug:   false,
-		githook: "pre-push",
+		githook: PrePush,
 	}
 	return runTalismanWithOptions(git, _options)
 }
@@ -209,6 +209,7 @@ type GitOperation func(*git_testing.GitTesting)
 func withNewTmpGitRepo(doGitOperation GitOperation) {
 	withNewTmpDirNamed("talisman-acceptance-test", func(gitPath string) {
 		gt := git_testing.Init(gitPath)
+		gt.RemoveHooks()
 		doGitOperation(gt)
 		os.RemoveAll(gitPath)
 	})

--- a/detector/detection_results_test.go
+++ b/detector/detection_results_test.go
@@ -35,9 +35,11 @@ func TestResultsReportsFailures(t *testing.T) {
 	results.Fail("another_filename", "Complete & utter failure")
 
 	actualErrorReport := results.ReportFileFailures("some_filename")
-	assert.Regexp(t, "The following errors were detected in some_filename", actualErrorReport, "Error report does not contain expected output")
-	assert.Regexp(t, "Bomb", actualErrorReport, "Error report does not contain expected output")
-	assert.Regexp(t, "Complete & utter failure", actualErrorReport, "Error report does not contain expected output")
+
+	assert.Regexp(t, "some_filename", actualErrorReport[0][0], "Error report does not contain expected output")
+	assert.Regexp(t, "Bomb", actualErrorReport[0][1], "Error report does not contain expected output")
+	assert.Regexp(t, "some_filename", actualErrorReport[1][0], "Error report does not contain expected output")
+	assert.Regexp(t, "Complete & utter failure", actualErrorReport[1][1], "Error report does not contain expected output")
 }
 
 // Presently not showing the ignored files in the log

--- a/detector/filename_detector.go
+++ b/detector/filename_detector.go
@@ -41,7 +41,6 @@ func DefaultFileNameDetector() Detector {
 		"^credentials\\.xml$",
 		"^.*\\.pubxml(\\.user)?$",
 		"^\\.?s3cfg$",
-		"^.*\\.ovpn$",
 		"^\\.gitrobrc$",
 		"^\\.?(bash|zsh)rc$",
 		"^\\.?(bash_|zsh_)?profile$",

--- a/git_testing/git_testing.go
+++ b/git_testing/git_testing.go
@@ -147,3 +147,7 @@ func (git *GitTesting) doInGitRoot(operation func()) {
 func (git *GitTesting) GetRoot() string {
 	return git.gitRoot
 }
+
+func (git *GitTesting) RemoveHooks() {
+	git.ExecCommand("rm", "-rf", ".git/hooks/")
+}

--- a/global_install_scripts/update_talisman.bash
+++ b/global_install_scripts/update_talisman.bash
@@ -1,0 +1,142 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s extglob
+
+DEBUG=${DEBUG:-''}
+FORCE_DOWNLOAD=${FORCE_DOWNLOAD:-''}
+
+function run() {
+
+    # Download appropriate (appropriate = based on OS and ARCH) talisman binary from github
+    # Copy the talisman binary to $TALISMAN_SETUP_DIR ($HOME/.talisman/bin)
+
+    declare TALISMAN_BINARY_NAME
+
+    IFS=$'\n'
+    VERSION=${VERSION:-'latest'}
+    INSTALL_ORG_REPO=${INSTALL_ORG_REPO:-'thoughtworks/talisman'}
+
+    TALISMAN_SETUP_DIR=${HOME}/.talisman/bin           # location of central install: talisman binary and hook script
+
+    TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'talisman_setup')
+    #trap "rm -r ${TEMP_DIR}" EXIT
+    chmod 0700 ${TEMP_DIR}
+
+    function echo_error() {
+	echo -ne $(tput setaf 1) >&2
+	echo "$1" >&2
+	echo -ne $(tput sgr0) >&2
+    }
+    export -f echo_error
+
+    function echo_debug() {
+	[[ -z "${DEBUG}" ]] && return
+	echo -ne $(tput setaf 3) >&2
+	echo "$1" >&2
+	echo -ne $(tput sgr0) >&2
+    }
+    export -f echo_debug
+
+    function echo_success {
+	echo -ne $(tput setaf 2)
+	echo "$1" >&2
+	echo -ne $(tput sgr0)
+    }
+    export -f echo_success
+
+    function collect_version_artifact_download_urls() {
+    echo "${TEMP_DIR}"
+	curl --silent "https://api.github.com/repos/${INSTALL_ORG_REPO}/releases/${VERSION}" |
+	    grep -e browser_download_url | grep -o 'https.*' | tr -d '"' > ${TEMP_DIR}/download_urls
+	echo "All release artifact download urls can be found at ${TEMP_DIR}/download_urls:"
+	[[ -z "${DEBUG}" ]] && return
+	cat ${TEMP_DIR}/download_urls
+	}
+
+    function set_talisman_binary_name() {
+	# based on OS (linux/darwin) and ARCH(32/64 bit)
+	echo_debug "Running set_talisman_binary_name"
+	declare ARCHITECTURE
+	OS=$(uname -s)
+	case $OS in
+	    "Linux")
+		ARCHITECTURE="linux" ;;
+	    "Darwin")
+		ARCHITECTURE="darwin" ;;
+		"MINGW32_NT-10.0-WOW")
+		ARCHITECTURE="windows" ;;
+		"MINGW64_NT-10.0")
+		ARCHITECTURE="windows" ;;
+		*)
+		echo_error "Talisman currently only supports Windows, Linux and MacOS(darwin) systems."
+		echo_error "If this is a problem for you, please open an issue: https://github.com/${INSTALL_ORG_REPO}/issues/new"
+		exit $E_UNSUPPORTED_ARCH
+		;;
+	esac
+
+	ARCH=$(uname -m)
+	case $ARCH in
+	    "x86_64")
+		ARCHITECTURE="${ARCHITECTURE}_amd64" ;;
+	    "i686" | "i386")
+		ARCHITECTURE="${ARCHITECTURE}_386" ;;
+		*)
+		echo_error "Talisman currently only supports x86 and x86_64 architectures."
+		echo_error "If this is a problem for you, please open an issue: https://github.com/${INSTALL_ORG_REPO}/issues/new"
+		exit $E_UNSUPPORTED_ARCH
+		;;
+    	esac
+
+	TALISMAN_BINARY_NAME="talisman_${ARCHITECTURE}"
+	if [[ "$OS" == "MINGW32_NT-10.0-WOW" || "$OS" == "MINGW64_NT-10.0" ]]; then
+		TALISMAN_BINARY_NAME="${TALISMAN_BINARY_NAME}.exe"
+	fi
+    }
+
+    function download() {
+    echo_debug "Running download()"
+	OBJECT=$1
+	DOWNLOAD_URL=$(grep 'http.*'${OBJECT}'$' ${TEMP_DIR}/download_urls)
+	echo_debug "Downloading ${OBJECT} from ${DOWNLOAD_URL}"
+	curl --location --silent ${DOWNLOAD_URL} > ${TEMP_DIR}/${OBJECT}
+    }
+
+    function verify_checksum() {
+	FILE_NAME=$1
+	CHECKSUM_FILE_NAME='checksums'
+	echo_debug "Verifying checksum for ${FILE_NAME}"
+	download ${CHECKSUM_FILE_NAME}
+
+	pushd ${TEMP_DIR} >/dev/null 2>&1
+	grep ${TALISMAN_BINARY_NAME} ${CHECKSUM_FILE_NAME} > ${CHECKSUM_FILE_NAME}.single
+	shasum -a 256 -c ${CHECKSUM_FILE_NAME}.single
+	popd >/dev/null 2>&1
+	echo_debug "Checksum verification successfull!"
+	echo
+    }
+
+    function download_talisman_binary() {
+    #download talisman binary
+    echo_debug "Running download_talisman_binary"
+	download ${TALISMAN_BINARY_NAME}
+	verify_checksum ${TALISMAN_BINARY_NAME}
+    }
+
+
+    function setup_talisman() {
+	# copy talisman binary from TEMP folder to the central location
+	rm -f ${TALISMAN_SETUP_DIR}/${TALISMAN_BINARY_NAME}
+	cp ${TEMP_DIR}/${TALISMAN_BINARY_NAME} ${TALISMAN_SETUP_DIR}
+	chmod +x ${TALISMAN_SETUP_DIR}/${TALISMAN_BINARY_NAME}
+    }
+
+	set_talisman_binary_name
+    echo "Downloading latest talisman binary"
+	collect_version_artifact_download_urls
+	download_talisman_binary
+	echo "Replacing talisman binary"
+    setup_talisman
+
+	}
+
+run $0 $@


### PR DESCRIPTION
This PR fixes the test case that was failing 'TestResultsReportsFailures' due to an earlier commit
It also adds curl update script 'update_talisman.bash' and related documentation 