### PR TITLE
refactored scanner to print commits with same failure message together

### DIFF
--- a/detector/detection_results_test.go
+++ b/detector/detection_results_test.go
@@ -25,8 +25,8 @@ func TestCanRecordMultipleErrorsAgainstASingleFile(t *testing.T) {
 	results.Fail("some_filename", "Bomb", []string{})
 	results.Fail("some_filename", "Complete & utter failure", []string{})
 	results.Fail("another_filename", "Complete & utter failure", []string{})
-	assert.Len(t, results.GetFailures("some_filename"), 2, "Expected two errors against some_filename.")
-	assert.Len(t, results.GetFailures("another_filename"), 1, "Expected one error against another_filename")
+	assert.Len(t, results.GetFailures("some_filename").FailuresInCommits, 2, "Expected two errors against some_filename.")
+	assert.Len(t, results.GetFailures("another_filename").FailuresInCommits, 1, "Expected one error against another_filename")
 }
 
 func TestResultsReportsFailures(t *testing.T) {
@@ -35,7 +35,7 @@ func TestResultsReportsFailures(t *testing.T) {
 	results.Fail("some_filename", "Complete & utter failure", []string{})
 	results.Fail("another_filename", "Complete & utter failure", []string{})
 
-	actualErrorReport := results.ReportFileFailures("some_filename", false)
+	actualErrorReport := results.ReportFileFailures("some_filename")
 	fmt.Println(actualErrorReport)
 
 	assert.Regexp(t, "some_filename", actualErrorReport[0][0], "Error report does not contain expected output")

--- a/detector/filecontent_detector_test.go
+++ b/detector/filecontent_detector_test.go
@@ -122,8 +122,9 @@ func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain hex encoded texts such as: " + hex
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[0].Message[0])
+	expectedMsg := make(map[string][]string)
+	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
+	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
 }
 
 func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -137,8 +138,11 @@ func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain hex encoded texts such as: " + hex
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[1].Message[0])
+	expectedMsg := make(map[string][]string)
+	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
+	expectedMsg["Expected file to not to contain base64 encoded texts such as: "+base64] = nil
+	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
+	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
 }
 
 func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -152,8 +156,10 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain base64 encoded texts such as: " + base64
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[0].Message[0])
+	expectedMsg := make(map[string][]string)
+	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
+	expectedMsg["Expected file to not to contain base64 encoded texts such as: "+base64] = nil
+	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
 }
 
 func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *testing.T) {
@@ -165,7 +171,7 @@ func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *te
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain credit card numbers such as: " +
-		creditCardNumber
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[0].Message[0])
+	expectedMsg := make(map[string][]string)
+	expectedMsg["Expected file to not to contain credit card numbers such as: "+creditCardNumber] = nil
+	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
 }

--- a/detector/filecontent_detector_test.go
+++ b/detector/filecontent_detector_test.go
@@ -122,9 +122,8 @@ func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := make(map[string][]string)
-	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
+	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 }
 
 func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -138,11 +137,8 @@ func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := make(map[string][]string)
-	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
-	expectedMsg["Expected file to not to contain base64 encoded texts such as: "+base64] = nil
-	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
+	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[1])
 }
 
 func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -156,10 +152,8 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := make(map[string][]string)
-	expectedMsg["Expected file to not to contain hex encoded texts such as: "+hex] = nil
-	expectedMsg["Expected file to not to contain base64 encoded texts such as: "+base64] = nil
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
+	expectedMessage := "Expected file to not to contain base64 encoded texts such as: " + base64
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 }
 
 func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *testing.T) {
@@ -171,7 +165,14 @@ func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *te
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := make(map[string][]string)
-	expectedMsg["Expected file to not to contain credit card numbers such as: "+creditCardNumber] = nil
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath).FailuresInCommits)
+	expectedMessage := "Expected file to not to contain credit card numbers such as: " + creditCardNumber
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
+}
+
+func getFailureMessages(results *DetectionResults, filePath git_repo.FilePath) []string {
+	failureMessages := []string{}
+	for failureMessage := range results.GetFailures(filePath).FailuresInCommits {
+		failureMessages = append(failureMessages, failureMessage)
+	}
+	return failureMessages
 }

--- a/detector/pattern_detector_test.go
+++ b/detector/pattern_detector_test.go
@@ -10,12 +10,12 @@ import (
 func TestShouldDetectPasswordPatterns(t *testing.T) {
 	filename := "secret.txt"
 
-	shouldPassDetectionOfSecretPattern(filename, []byte("\"password\" : UnsafePassword"), t)
-	shouldPassDetectionOfSecretPattern(filename, []byte("<password data=123> jdghfakjkdha</password>"), t)
-	shouldPassDetectionOfSecretPattern(filename, []byte("<passphrase data=123> AasdfYlLKHKLasdKHAFKHSKmlahsdfLK</passphrase>"), t)
-	shouldPassDetectionOfSecretPattern(filename, []byte("<ConsumerKey>alksjdhfkjaklsdhflk12345adskjf</ConsumerKey>"), t)
-	shouldPassDetectionOfSecretPattern(filename, []byte("AWS key :"), t)
-	shouldPassDetectionOfSecretPattern(filename, []byte(`BEGIN RSA PRIVATE KEY-----
+	shouldPassDetectionOfSecretPattern(filename, []byte("Potential secret pattern : \"password\" : UnsafePassword"), t)
+	shouldPassDetectionOfSecretPattern(filename, []byte("Potential secret pattern : <password data=123> jdghfakjkdha</password>"), t)
+	shouldPassDetectionOfSecretPattern(filename, []byte("Potential secret pattern : <passphrase data=123> AasdfYlLKHKLasdKHAFKHSKmlahsdfLK</passphrase>"), t)
+	shouldPassDetectionOfSecretPattern(filename, []byte("Potential secret pattern : <ConsumerKey>alksjdhfkjaklsdhflk12345adskjf</ConsumerKey>"), t)
+	shouldPassDetectionOfSecretPattern(filename, []byte("Potential secret pattern : AWS key :"), t)
+	shouldPassDetectionOfSecretPattern(filename, []byte(`Potential secret pattern : BEGIN RSA PRIVATE KEY-----
 aghjdjadslgjagsfjlsgjalsgjaghjldasja
 -----END RSA PRIVATE KEY`), t)
 }
@@ -36,5 +36,12 @@ func shouldPassDetectionOfSecretPattern(filename string, content []byte, t *test
 	results := NewDetectionResults()
 	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
 	NewPatternDetector().Test(additions, TalismanRCIgnore{}, results)
-	assert.Equal(t, "Potential secret pattern : "+string(content), results.GetFailures(additions[0].Path)[0].Message[0])
+	expected := getMapOfEmptyCommits(content)
+	assert.Equal(t, expected, results.GetFailures(additions[0].Path).FailuresInCommits)
+}
+
+func getMapOfEmptyCommits(content []byte) map[string][]string {
+	failuresInCommits := make(map[string][]string)
+	failuresInCommits[string(content)] = nil
+	return failuresInCommits
 }

--- a/report/report.go
+++ b/report/report.go
@@ -279,18 +279,16 @@ func getReportHTML() string {
 							<td>{{$filePath}}</td>
 							<td>
 								<table class="details">
-									{{range $failure := $FailureData}}
+									{{range $failureMessage, $commits := $FailureData.FailuresInCommits}}
 										<tr>
 											<td class="failure-message">
-												{{range $failureMsg := $failure.Message}}
-													{{$failureMsg}}
-												{{end}}
+												{{$failureMessage}}
 											</td>
 											<td>
 												<table>
-													{{range $commit := $failure.Commits}}
-														<tr><td>{{$commit}}</td></tr>
-													{{end}}
+												{{range $commit := $commits}}
+													<tr><td>{{$commit}}</td></tr>
+												{{end}}
 												</table>
 											</td>
 										</tr>


### PR DESCRIPTION
The scanner used to print all the failures of a file together, although the commits were not getting repeated, the messages were getting printed several times with different commits the messages belonged to. This commit adds printing of each message only once and the commits together.