### PR TITLE
Corrected test cases where go lang array slices are behaving differently on different OS.

### DIFF
--- a/detector/detection_results_test.go
+++ b/detector/detection_results_test.go
@@ -1,6 +1,7 @@
 package detector
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,11 +36,13 @@ func TestResultsReportsFailures(t *testing.T) {
 	results.Fail("another_filename", "Complete & utter failure", []string{})
 
 	actualErrorReport := results.ReportFileFailures("some_filename")
+	firstErrorMessage := strings.Join(actualErrorReport[0], " ")
+	secondErrorMessage := strings.Join(actualErrorReport[1], " ")
+	finalStringMessage := firstErrorMessage + " " + secondErrorMessage
 
-	assert.Regexp(t, "some_filename", actualErrorReport[0][0], "Error report does not contain expected output")
-	assert.Regexp(t, "Bomb", actualErrorReport[0][1], "Error report does not contain expected output")
-	assert.Regexp(t, "some_filename", actualErrorReport[1][0], "Error report does not contain expected output")
-	assert.Regexp(t, "Complete & utter failure", actualErrorReport[1][1], "Error report does not contain expected output")
+	assert.Regexp(t, "some_filename", finalStringMessage, "Error report does not contain expected output")
+	assert.Regexp(t, "Bomb", finalStringMessage, "Error report does not contain expected output")
+	assert.Regexp(t, "Complete & utter failure", finalStringMessage, "Error report does not contain expected output")
 }
 
 // Presently not showing the ignored files in the log

--- a/detector/filecontent_detector_test.go
+++ b/detector/filecontent_detector_test.go
@@ -1,6 +1,7 @@
 package detector
 
 import (
+	"strings"
 	"talisman/git_repo"
 	"testing"
 
@@ -138,8 +139,8 @@ func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
 	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
-	messageReceived := getFailureMessages(results, filePath)[1]
-	assert.Equal(t, expectedMessage, messageReceived)
+	messageReceived := strings.Join(getFailureMessages(results, filePath), " ")
+	assert.Regexp(t, expectedMessage, messageReceived, "Should contain hex detection message")
 }
 
 func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -154,8 +155,8 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
 	expectedMessage := "Expected file to not to contain base64 encoded texts such as: " + base64
-	messageReceived := getFailureMessages(results, filePath)[0]
-	assert.Equal(t, expectedMessage, messageReceived)
+	messageReceived := strings.Join(getFailureMessages(results, filePath), " ")
+	assert.Regexp(t, expectedMessage, messageReceived, "Should contain base64 detection message")
 }
 
 func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *testing.T) {


### PR DESCRIPTION
This PR fixes

- Test cases where assertions are made using array slices explicitly by mentioning the index of the messages (this is causing messages to be reindexed at different index in different OS and failing test cases sometimes).