### PR TITLE
Modified the scan logic for pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Find the instructions below.
 ## [Recommended approach]
 ## Installation as a global hook template 
 
-We recommend installing Talisman as a git hook template, as that will cause
+We recommend installing Talisman as a **pre-commit git hook template**, as that will cause
 Talisman to be present, not only in your existing git repositories, but also in any new repository that you 'init' or
 'clone'.
 
@@ -226,6 +226,10 @@ In the above example, the file *danger.pem* has been flagged as a security breac
 * The filename matches one of the pre-configured patterns.
 * The file contains an awsSecretKey which is scanned and flagged by Talisman
 
+If you have installed Talisman as a pre-commit hook, it will scan only the _diff_ within each commit. This means that it would only report errors for parts of the file that were changed.
+
+In case you have installed Talisman as a pre-push hook, it will scan the complete file in which changes are made. As mentioned above, it is recommended that you use Talisman as a **pre-commit hook**.
+
 ## Validations
 The following detectors execute against the changesets to detect secrets/sensitive information:
 
@@ -321,7 +325,6 @@ In case you want to store the reports in some other location, it can be provided
 * `talisman --scan --rd=/Users/username/Desktop`
 
 <i>Talisman currently does not support ignoring of files for scanning.</i>
-
 # Uninstallation
 The uninstallation process depends on how you had installed Talisman.
 You could have chosen to install as a global hook template or at a single repository.

--- a/detector/checksum_compare.go
+++ b/detector/checksum_compare.go
@@ -16,6 +16,20 @@ func NewChecksumCompare(gitAdditions []git_repo.Addition, talismanRCIgnoreConfig
 	return &cc
 }
 
+func (cc *ChecksumCompare) IsScanNotRequired(addition git_repo.Addition) bool {
+	currentCollectiveChecksum := utility.CollectiveSHA256Hash([]string{string(addition.Path)})
+	declaredCheckSum := ""
+	for _, ignore := range cc.ignoreConfig.FileIgnoreConfig {
+		if addition.Matches(ignore.FileName) {
+			currentCollectiveChecksum = utility.CollectiveSHA256Hash([]string{ignore.FileName})
+			declaredCheckSum = ignore.Checksum
+		}
+
+	}
+	return currentCollectiveChecksum == declaredCheckSum
+
+}
+
 //FilterIgnoresBasedOnChecksums filters the file ignores from the TalismanRCIgnore which doesn't have any checksum value or having mismatched checksum value from the .talsimanrc
 func (cc *ChecksumCompare) FilterIgnoresBasedOnChecksums() TalismanRCIgnore {
 	finalIgnores := []FileIgnoreConfig{}

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -47,9 +47,7 @@ func (dc *Chain) Test(additions []git_repo.Addition, ignoreConfig TalismanRCIgno
 	repo := git_repo.RepoLocatedAt(wd)
 	gitTrackedFilesAsAdditions := repo.TrackedFilesAsAdditions()
 	gitTrackedFilesAsAdditions = append(gitTrackedFilesAsAdditions, additions...)
-	cc := NewChecksumCompare(gitTrackedFilesAsAdditions, ignoreConfig)
-	ignoreConfigFiltered := cc.FilterIgnoresBasedOnChecksums()
 	for _, v := range dc.detectors {
-		v.Test(additions, ignoreConfigFiltered, result)
+		v.Test(additions, ignoreConfig, result)
 	}
 }

--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -32,8 +32,9 @@ func (fc *FileContentDetector) AggressiveMode() *FileContentDetector {
 }
 
 func (fc *FileContentDetector) Test(additions []git_repo.Addition, ignoreConfig TalismanRCIgnore, result *DetectionResults) {
+	cc := NewChecksumCompare(additions, ignoreConfig)
 	for _, addition := range additions {
-		if ignoreConfig.Deny(addition, "filecontent") {
+		if ignoreConfig.Deny(addition, "filecontent") || cc.IsScanNotRequired(addition) {
 			log.WithFields(log.Fields{
 				"filePath": addition.Path,
 			}).Info("Ignoring addition as it was specified to be ignored.")

--- a/detector/filename_detector.go
+++ b/detector/filename_detector.go
@@ -77,8 +77,9 @@ func NewFileNameDetector(patternStrings ...string) Detector {
 
 //Test tests the fileNames of the Additions to ensure that they don't look suspicious
 func (fd FileNameDetector) Test(additions []git_repo.Addition, ignoreConfig TalismanRCIgnore, result *DetectionResults) {
+	cc := NewChecksumCompare(additions, ignoreConfig)
 	for _, addition := range additions {
-		if ignoreConfig.Deny(addition, "filename") {
+		if ignoreConfig.Deny(addition, "filename") || cc.IsScanNotRequired(addition){
 			log.WithFields(log.Fields{
 				"filePath": addition.Path,
 			}).Info("Ignoring addition as it was specified to be ignored.")

--- a/detector/filesize_detector.go
+++ b/detector/filesize_detector.go
@@ -21,8 +21,9 @@ func NewFileSizeDetector(size int) Detector {
 }
 
 func (fd FileSizeDetector) Test(additions []git_repo.Addition, ignoreConfig TalismanRCIgnore, result *DetectionResults) {
+	cc := NewChecksumCompare(additions, ignoreConfig)
 	for _, addition := range additions {
-		if ignoreConfig.Deny(addition, "filesize") {
+		if ignoreConfig.Deny(addition, "filesize") || cc.IsScanNotRequired(addition) {
 			log.WithFields(log.Fields{
 				"filePath": addition.Path,
 			}).Info("Ignoring addition as it was specified to be ignored.")

--- a/detector/pattern_detector.go
+++ b/detector/pattern_detector.go
@@ -13,8 +13,9 @@ type PatternDetector struct {
 
 //Test tests the contents of the Additions to ensure that they don't look suspicious
 func (detector PatternDetector) Test(additions []git_repo.Addition, ignoreConfig TalismanRCIgnore, result *DetectionResults) {
+	cc := NewChecksumCompare(additions, ignoreConfig)
 	for _, addition := range additions {
-		if ignoreConfig.Deny(addition, "filecontent") {
+		if ignoreConfig.Deny(addition, "filecontent") || cc.IsScanNotRequired(addition) {
 			log.WithFields(log.Fields{
 				"filePath": addition.Path,
 			}).Info("Ignoring addition as it was specified to be ignored.")

--- a/git_testing/git_testing.go
+++ b/git_testing/git_testing.go
@@ -107,12 +107,16 @@ func (git *GitTesting) FileContents(filePath string) []byte {
 }
 
 func (git *GitTesting) AddAndcommit(fileName string, message string) {
-	git.ExecCommand("git", "add", fileName)
-	git.ExecCommand("git", "commit", fileName, "-m", message)
+	git.Add(fileName)
+	git.Commit(fileName, message)
 }
 
 func (git *GitTesting) Add(fileName string) {
 	git.ExecCommand("git", "add", fileName)
+}
+
+func (git *GitTesting) Commit(fileName string, message string) {
+	git.ExecCommand("git", "commit", fileName, "-m", message)
 }
 
 func (git *GitTesting) GetBlobDetails(fileName string) string {

--- a/pre_commit_hook.go
+++ b/pre_commit_hook.go
@@ -15,5 +15,5 @@ func NewPreCommitHook() *PreCommitHook {
 func (p *PreCommitHook) GetRepoAdditions() []git_repo.Addition {
 	wd, _ := os.Getwd()
 	repo := git_repo.RepoLocatedAt(wd)
-	return repo.StagedAdditions()
+	return repo.GetDiffForStagedFiles()
 }


### PR DESCRIPTION
The scan logic has now been updated to scan only the diff for each file if Talisman is being used as a pre-commit hook.
For pre-push hook and scan functionalities, Talisman will continue to scan the whole file.
Stops the scan in scenarios where the checksum is matching