### PR TITLE
Fixed crash when staged file doesn't contain '\t'

### DIFF
--- a/git_repo/git_repo.go
+++ b/git_repo/git_repo.go
@@ -180,8 +180,11 @@ func (repo GitRepo) stagedFiles() []string {
 	var result []string
 	for _, c := range stagedFiles {
 		if len(c) != 0 {
-			file := strings.Split(c, "\t")[1]
-			result = append(result, file)
+			changeTypeAndFile := strings.Split(c, "\t")
+			if len(changeTypeAndFile) > 0 {
+				file := changeTypeAndFile[1]
+				result = append(result, file)
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
Fix for https://github.com/thoughtworks/talisman/issues/124