### PR TITLE
Handle error in report go

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -13,9 +13,6 @@ import (
 	"github.com/fatih/color"
 )
 
-var reportsFolder string
-
-const htmlFileName string = "report.html"
 const jsonFileName string = "report.json"
 const htmlReportDir string = "talisman_html_report"
 
@@ -24,18 +21,18 @@ func GenerateReport(r *detector.DetectionResults, directory string) string {
 
 	var path string
 	var jsonFilePath string
-	var home_dir string
-	var base_report_dir_path string
+	var homeDir string
+	var baseReportDirPath string
 
 	usr, err := user.Current()
-	home_dir = usr.HomeDir
+	homeDir = usr.HomeDir
 
 	if directory == htmlReportDir {
 		path = directory
-		base_report_dir_path = filepath.Join(home_dir, ".talisman", htmlReportDir)
+		baseReportDirPath = filepath.Join(homeDir, ".talisman", htmlReportDir)
 		jsonFilePath = filepath.Join(path, "/data", jsonFileName)
 		os.MkdirAll(path, 0755)
-		err = utility.Dir(base_report_dir_path, htmlReportDir)
+		err = utility.Dir(baseReportDirPath, htmlReportDir)
 		if err != nil {
 			generateErrorMsg()
 		}

--- a/runner.go
+++ b/runner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"talisman/checksumcalculator"
 	"talisman/detector"
@@ -48,7 +49,11 @@ func (r *Runner) Scan(reportDirectory string) int {
 	additions := scanner.GetAdditions()
 	ignores := detector.TalismanRCIgnore{}
 	detector.DefaultChain().Test(additions, ignores, r.results)
-	reportsPath := report.GenerateReport(r.results, reportDirectory)
+	reportsPath, err := report.GenerateReport(r.results, reportDirectory)
+	if err != nil {
+		log.Printf("error while generating report: %v", err)
+		return CompletedWithErrors
+	}
 	fmt.Printf("\nPlease check '%s' folder for the talisman scan report\n", reportsPath)
 	fmt.Printf("\n")
 	return r.exitStatus()


### PR DESCRIPTION
Currently we are **not returning error** in `GenerateReport` function. It is better to send error to caller and let the caller decide what to do with the errors.

>Note: Made fix with the small context I have on talisman. Please let me know if I made any mistake.