### PR TITLE
Improve performance

### DIFF
--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -51,7 +51,7 @@ func (ct contentType) getInfo() string {
 	return ""
 }
 
-func (ct contentType) getOutput() string {
+func (ct contentType) getMessageFormat() string {
 	switch ct {
 	case base64Content:
 		return "Expected file to not to contain base64 encoded texts such as: %s"
@@ -145,9 +145,9 @@ func processContent(c content, result *DetectionResults) {
 				"filePath": c.path,
 			}).Info(c.contentType.getInfo())
 			if string(c.name) == DefaultRCFileName {
-				result.Warn(c.path, "filecontent", fmt.Sprintf(c.contentType.getOutput(), res), []string{})
+				result.Warn(c.path, "filecontent", fmt.Sprintf(c.contentType.getMessageFormat(), res), []string{})
 			} else {
-				result.Fail(c.path, "filecontent", fmt.Sprintf(c.contentType.getOutput(), res), []string{})
+				result.Fail(c.path, "filecontent", fmt.Sprintf(c.contentType.getMessageFormat(), res), []string{})
 			}
 		}
 	}

--- a/detector/pattern_detector.go
+++ b/detector/pattern_detector.go
@@ -41,12 +41,14 @@ func (detector PatternDetector) Test(additions []gitrepo.Addition, ignoreConfig 
 		close(matches)
 		close(ignoredFilePaths)
 	}()
-	for i := 0; i < len(additions); i++ {
+	for ignoredChanHasMore, matchChanHasMore := true, true; ignoredChanHasMore || matchChanHasMore; {
 		select {
-		case match := <-matches:
+		case match, hasMore := <-matches:
 			detector.processMatch(match, result)
-		case ignore := <-ignoredFilePaths:
+			matchChanHasMore = hasMore
+		case ignore, hasMore := <-ignoredFilePaths:
 			detector.processIgnore(ignore, result)
+			ignoredChanHasMore = hasMore
 		}
 	}
 }


### PR DESCRIPTION
Co-authored-by: @aswinkarthik

We introduced `go routines` in pattern detector and file content detector to
make things in parallel.

### Results:
For a codebase which had 600 newly added files

Before our change:
```bash
time ~/.talisman/bin/talisman_darwin_amd64 --githook pre-commit >/dev/null

real    0m14.029s
user    0m12.035s
sys     0m2.216s
```

After our change:
```bash
time ./talisman_darwin_amd64 --githook pre-commit >/dev/null
real    0m7.797s
user    0m19.857s
sys     0m2.336s
```

#### Method level metrics:
```yaml
Pattern Detector:
    Before: 5.498711305s
    After: 1.898453802s

Content Detector:
    Before: 639.769275m
    After: 221.733402ms
```