### PR TITLE
Fix empty error message in GenerateReport function

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -17,9 +17,8 @@ const jsonFileName string = "report.json"
 const htmlReportDir string = "talisman_html_report"
 
 // GenerateReport generates a talisman scan report in html format
-func GenerateReport(r *detector.DetectionResults, directory string) (string, error) {
+func GenerateReport(r *detector.DetectionResults, directory string) (path string, err error) {
 
-	var path string
 	var jsonFilePath string
 	var homeDir string
 	var baseReportDirPath string
@@ -51,8 +50,9 @@ func GenerateReport(r *detector.DetectionResults, directory string) (string, err
 
 	jsonFile, err := os.Create(jsonFilePath)
 	defer func() {
-		err = jsonFile.Close()
-		log.Fatalf("error closing file %s: %v", jsonFilePath, err)
+		if err = jsonFile.Close(); err != nil {
+			err = fmt.Errorf("error closing file %s: %v", jsonFilePath, err)
+		}
 	}()
 
 	if err != nil {


### PR DESCRIPTION
Current behaviour
```
$ talisman --scan


d8888b. db    db d8b   db d8b   db d888888b d8b   db  d888b    .d8888.  .o88b.  .d8b.  d8b   db
88  `8D 88    88 888o  88 888o  88   `88'   888o  88 88' Y8b   88'  YP d8P  Y8 d8' `8b 888o  88
88oobY' 88    88 88V8o 88 88V8o 88    88    88V8o 88 88        `8bo.   8P      88ooo88 88V8o 88
88`8b   88    88 88 V8o88 88 V8o88    88    88 V8o88 88  ooo     `Y8b. 8b      88~~~88 88 V8o88
88 `88. 88b  d88 88  V888 88  V888   .88.   88  V888 88. ~8~   db   8D Y8b  d8 88   88 88  V888 db db
88   YD ~Y8888P' VP   V8P VP   V8P Y888888P VP   V8P  Y888P    `8888Y'  `Y88P' YP   YP VP   V8P VP VP


2019/10/12 12:52:24 error closing file talisman_reports/data/report.json: <nil>
```