### PR TITLE
Encapsulate check function with content-type

### DIFF
--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -64,7 +64,7 @@ func (ct contentType) getMessageFormat() string {
 	return ""
 }
 
-func (ct contentType) getCheckFn() func(fc *FileContentDetector, word string) string {
+func (ct contentType) getCheckFn() fn {
 	switch ct {
 	case base64Content:
 		return checkBase64


### PR DESCRIPTION
Minor refactoring to contentType enum. Encapsulated the check function with the type instead of a separate struct.