### PR TITLE
detector: compile regular expressions at build time...

### DIFF
--- a/detector/match_pattern.go
+++ b/detector/match_pattern.go
@@ -20,14 +20,6 @@ func (detector PatternMatcher) check(content string) []string {
 	return []string{""}
 }
 
-func initPattern(patternStrings []string) *PatternMatcher {
-	var patterns = make([]*regexp.Regexp, len(patternStrings))
-	for i, pattern := range patternStrings {
-		patterns[i], _ = regexp.Compile(pattern)
-	}
+func NewSecretsPatternDetector(patterns []*regexp.Regexp) *PatternMatcher {
 	return &PatternMatcher{patterns}
-}
-
-func NewSecretsPatternDetector(patterns []string) *PatternMatcher {
-	return initPattern(patterns)
 }

--- a/detector/match_pattern_test.go
+++ b/detector/match_pattern_test.go
@@ -2,14 +2,20 @@ package detector
 
 import (
 	"github.com/stretchr/testify/assert"
+	"regexp"
 	"testing"
 )
 
+var (
+	testRegexpPassword = regexp.MustCompile(`(?i)(['|"|_]?password['|"]? *[:|=][^,|;]{8,})`)
+	testRegexpPw       = regexp.MustCompile(`(?i)(['|"|_]?pw['|"]? *[:|=][^,|;]{8,})`)
+)
+
 func TestShouldReturnEmptyStringWhenDoesNotMatchAnyRegex(t *testing.T) {
-	assert.Equal(t, "", NewSecretsPatternDetector([]string{"(?i)(['|\"|_]?password['|\"]? *[:|=][^,|;]{8,})"}).check("safeString")[0])
+	assert.Equal(t, "", NewSecretsPatternDetector([]*regexp.Regexp{testRegexpPassword}).check("safeString")[0])
 }
 
 func TestShouldReturnStringWhenMatchedPasswordPattern(t *testing.T) {
-	assert.Equal(t, []string{"password\" :  123456789"}, NewSecretsPatternDetector([]string{"(?i)(['|\"|_]?password['|\"]? *[:|=][^,|;]{8,})"}).check("password\" :  123456789"))
-	assert.Equal(t, []string{"pw\"  :  123456789"}, NewSecretsPatternDetector([]string{"(?i)(['|\"|_]?pw['|\"]? *[:|=][^,|;]{8,})"}).check("pw\"  :  123456789"))
+	assert.Equal(t, []string{"password\" :  123456789"}, NewSecretsPatternDetector([]*regexp.Regexp{testRegexpPassword}).check("password\" :  123456789"))
+	assert.Equal(t, []string{"pw\"  :  123456789"}, NewSecretsPatternDetector([]*regexp.Regexp{testRegexpPw}).check("pw\"  :  123456789"))
 }

--- a/detector/pattern_detector.go
+++ b/detector/pattern_detector.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"regexp"
 	"sync"
 	"talisman/gitrepo"
 )
@@ -10,6 +11,25 @@ import (
 type PatternDetector struct {
 	secretsPattern *PatternMatcher
 }
+
+var (
+	detectorPatterns = []*regexp.Regexp{
+		regexp.MustCompile("(?i)(['|\"|_]?password['|\"]? *[:|=][^,|;|\n]{8,})"),
+		regexp.MustCompile("(?i)(['|\"|_]?pw['|\"]? *[:|=][^,|;|\n]{8,})"),
+		regexp.MustCompile("(?i)(['|\"|_]?pwd['|\"]? *[:|=][^,|;|\n]{8,})"),
+		regexp.MustCompile("(?i)(['|\"|_]?pass['|\"]? *[:|=][^,|;|\n]{8,})"),
+		regexp.MustCompile("(?i)(['|\"|_]?pword['|\"]? *[:|=][^,|;|\n]{8,})"),
+		regexp.MustCompile("(?i)(['|\"|_]?adminPassword['|\"]? *[:|=|\n][^,|;]{8,})"),
+		regexp.MustCompile("(?i)(['|\"|_]?passphrase['|\"]? *[:|=|\n][^,|;]{8,})"),
+		regexp.MustCompile("(<[^(><.)]?password[^(><.)]*?>[^(><.)]+</[^(><.)]?password[^(><.)]*?>)"),
+		regexp.MustCompile("(<[^(><.)]?passphrase[^(><.)]*?>[^(><.)]+</[^(><.)]?passphrase[^(><.)]*?>)"),
+		regexp.MustCompile("(?i)(<ConsumerKey>\\S*<\\/ConsumerKey>)"),
+		regexp.MustCompile("(?i)(<ConsumerSecret>\\S*<\\/ConsumerSecret>)"),
+		regexp.MustCompile("(?i)(AWS[ |\\w]+key[ |\\w]+[:|=])"),
+		regexp.MustCompile("(?i)(AWS[ |\\w]+secret[ |\\w]+[:|=])"),
+		regexp.MustCompile("(?s)(BEGIN RSA PRIVATE KEY.*END RSA PRIVATE KEY)"),
+	}
+)
 
 type match struct {
 	name       gitrepo.FileName
@@ -82,22 +102,5 @@ func (detector PatternDetector) processMatch(match match, result *DetectionResul
 
 //NewPatternDetector returns a PatternDetector that tests Additions against the pre-configured patterns
 func NewPatternDetector() *PatternDetector {
-	patternStrings := []string{
-		"(?i)(['|\"|_]?password['|\"]? *[:|=][^,|;|\n]{8,})",
-		"(?i)(['|\"|_]?pw['|\"]? *[:|=][^,|;|\n]{8,})",
-		"(?i)(['|\"|_]?pwd['|\"]? *[:|=][^,|;|\n]{8,})",
-		"(?i)(['|\"|_]?pass['|\"]? *[:|=][^,|;|\n]{8,})",
-		"(?i)(['|\"|_]?pword['|\"]? *[:|=][^,|;|\n]{8,})",
-		"(?i)(['|\"|_]?adminPassword['|\"]? *[:|=|\n][^,|;]{8,})",
-		"(?i)(['|\"|_]?passphrase['|\"]? *[:|=|\n][^,|;]{8,})",
-		"(<[^(><.)]?password[^(><.)]*?>[^(><.)]+</[^(><.)]?password[^(><.)]*?>)",
-		"(<[^(><.)]?passphrase[^(><.)]*?>[^(><.)]+</[^(><.)]?passphrase[^(><.)]*?>)",
-		"(?i)(<ConsumerKey>\\S*<\\/ConsumerKey>)",
-		"(?i)(<ConsumerSecret>\\S*<\\/ConsumerSecret>)",
-		"(?i)(AWS[ |\\w]+key[ |\\w]+[:|=])",
-		"(?i)(AWS[ |\\w]+secret[ |\\w]+[:|=])",
-		"(?s)(BEGIN RSA PRIVATE KEY.*END RSA PRIVATE KEY)",
-	}
-
-	return &PatternDetector{NewSecretsPatternDetector(patternStrings)}
+	return &PatternDetector{NewSecretsPatternDetector(detectorPatterns)}
 }


### PR DESCRIPTION
... instead of at runtime, improves #152

Some notes on this pull request:
* It seems `go fmt` was not used. I've not committed any other files that would have been impacted by `go fmt`
* In `detector/match_pattern_test.go` I took the liberty to use the backtick as string delimiter. Only `"` needed to be escaped, so using backticks makes this more clear.
    * Note that I left the patterns in `detector/match_pattern.go` untouched from the above becaue you want to match on `\n`.
* After running `go mod vendor && ./build && cd vendor`, I ran the following command:
```
$ time ../talisman_linux_amd64 --githook pre-commit >/dev/null

real	0m4.687s
user	0m15.094s
sys	0m0.090s
```
compared to
```
real    0m2.707s
user    0m11.829s
sys     0m0.219s
```
from #152.

The only improvement is in `sys` ("system time" and "system time of children" according to `man 2 times`) by about 120ms. I cannot seem to find how @aswinkarthik produced the per-function stats, so I would be eager to know whether this PR improves those as well. There should be _some_ improvement, because this PR compiles the static regular expressions at build time.