### PR TITLE
Fix travisci to use latest stable version of go for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
   - GO111MODULE=on
 go:
-- 1.11.x
+- stable
 before_install:
 - go get github.com/mattn/goveralls
 install: true


### PR DESCRIPTION
Use current stable go version instead of pinning it to a version