### PR TITLE
detector: remove confusing/incorrectly used | in character classes of detectorPatterns

### DIFF
--- a/detector/match_pattern_test.go
+++ b/detector/match_pattern_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	testRegexpPassword = regexp.MustCompile(`(?i)(['|"|_]?password['|"]? *[:|=][^,|;]{8,})`)
-	testRegexpPw       = regexp.MustCompile(`(?i)(['|"|_]?pw['|"]? *[:|=][^,|;]{8,})`)
+	testRegexpPassword = regexp.MustCompile(`(?i)(['"_]?password['"]? *[:=][^,;]{8,})`)
+	testRegexpPw       = regexp.MustCompile(`(?i)(['"_]?pw['"]? *[:=][^,;]{8,})`)
 )
 
 func TestShouldReturnEmptyStringWhenDoesNotMatchAnyRegex(t *testing.T) {

--- a/detector/pattern_detector.go
+++ b/detector/pattern_detector.go
@@ -14,19 +14,19 @@ type PatternDetector struct {
 
 var (
 	detectorPatterns = []*regexp.Regexp{
-		regexp.MustCompile("(?i)(['|\"|_]?password['|\"]? *[:|=][^,|;|\n]{8,})"),
-		regexp.MustCompile("(?i)(['|\"|_]?pw['|\"]? *[:|=][^,|;|\n]{8,})"),
-		regexp.MustCompile("(?i)(['|\"|_]?pwd['|\"]? *[:|=][^,|;|\n]{8,})"),
-		regexp.MustCompile("(?i)(['|\"|_]?pass['|\"]? *[:|=][^,|;|\n]{8,})"),
-		regexp.MustCompile("(?i)(['|\"|_]?pword['|\"]? *[:|=][^,|;|\n]{8,})"),
-		regexp.MustCompile("(?i)(['|\"|_]?adminPassword['|\"]? *[:|=|\n][^,|;]{8,})"),
-		regexp.MustCompile("(?i)(['|\"|_]?passphrase['|\"]? *[:|=|\n][^,|;]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?password['\"]? *[:=][^,;\n]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?pw['\"]? *[:=][^,;\n]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?pwd['\"]? *[:=][^,;\n]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?pass['\"]? *[:=][^,;\n]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?pword['\"]? *[:=][^,;\n]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?adminPassword['\"]? *[:=\n][^,;]{8,})"),
+		regexp.MustCompile("(?i)(['\"_]?passphrase['\"]? *[:=\n][^,;]{8,})"),
 		regexp.MustCompile("(<[^(><.)]?password[^(><.)]*?>[^(><.)]+</[^(><.)]?password[^(><.)]*?>)"),
 		regexp.MustCompile("(<[^(><.)]?passphrase[^(><.)]*?>[^(><.)]+</[^(><.)]?passphrase[^(><.)]*?>)"),
 		regexp.MustCompile("(?i)(<ConsumerKey>\\S*<\\/ConsumerKey>)"),
 		regexp.MustCompile("(?i)(<ConsumerSecret>\\S*<\\/ConsumerSecret>)"),
-		regexp.MustCompile("(?i)(AWS[ |\\w]+key[ |\\w]+[:|=])"),
-		regexp.MustCompile("(?i)(AWS[ |\\w]+secret[ |\\w]+[:|=])"),
+		regexp.MustCompile("(?i)(AWS[ \\w]+key[ \\w]+[:=])"),
+		regexp.MustCompile("(?i)(AWS[ \\w]+secret[ \\w]+[:=])"),
 		regexp.MustCompile("(?s)(BEGIN RSA PRIVATE KEY.*END RSA PRIVATE KEY)"),
 	}
 )


### PR DESCRIPTION
Fixes #161