### PR TITLE
[Issue #174] | Truncate content when reporting error

### DIFF
--- a/detector/filecontent_detector.go
+++ b/detector/filecontent_detector.go
@@ -159,12 +159,19 @@ func processContent(c content, result *DetectionResults) {
 				"filePath": c.path,
 			}).Info(c.contentType.getInfo())
 			if string(c.name) == talismanrc.DefaultRCFileName {
-				result.Warn(c.path, "filecontent", fmt.Sprintf(c.contentType.getMessageFormat(), res), []string{})
+				result.Warn(c.path, "filecontent", fmt.Sprintf(c.contentType.getMessageFormat(), formatForReporting(res)), []string{})
 			} else {
-				result.Fail(c.path, "filecontent", fmt.Sprintf(c.contentType.getMessageFormat(), res), []string{})
+				result.Fail(c.path, "filecontent", fmt.Sprintf(c.contentType.getMessageFormat(), formatForReporting(res)), []string{})
 			}
 		}
 	}
+}
+
+func formatForReporting(input string) string {
+	if len(input) > 50 {
+		return input[:47] + "..."
+	}
+	return input
 }
 
 func (fc *FileContentDetector) detectFile(data []byte, getResult fn) []string {


### PR DESCRIPTION
Truncate content when reporting error instead of showing the full content that caused the detector to fire