### PR TITLE
Issue #185:Changed the pattern checking for passwords to verify strin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ detector/.talismanrc
 .vscode/**
 coverage.out
 coverage.txt
+.talismanrc

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,6 @@
 fileignoreconfig:
+- filename: detector/pattern_detector_test.go
+  checksum: fbb55705e75e1fcba609b10c454e277e5c67c930bd5aedd514055570e2b868b4
 - filename: detector/detection_results_test.go
   checksum: 69fed055782cddfe0f0d23ea440cef9f9dd0b9e8a3c8a73856741bb26257b223
   ignore_detectors:

--- a/detector/pattern_detector.go
+++ b/detector/pattern_detector.go
@@ -16,15 +16,8 @@ type PatternDetector struct {
 
 var (
 	detectorPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)(['"_]?password['"]? *[:=][^,;\n]{8,})`),
+		regexp.MustCompile(`(?i)((.*)(password|passphrase|secret|key|pwd|pword|pass)(.*) *[:=>][^,;\n]{8,})`),
 		regexp.MustCompile(`(?i)(['"_]?pw['"]? *[:=][^,;\n]{8,})`),
-		regexp.MustCompile(`(?i)(['"_]?pwd['"]? *[:=][^,;\n]{8,})`),
-		regexp.MustCompile(`(?i)(['"_]?pass['"]? *[:=][^,;\n]{8,})`),
-		regexp.MustCompile(`(?i)(['"_]?pword['"]? *[:=][^,;\n]{8,})`),
-		regexp.MustCompile(`(?i)(['"_]?adminPassword['"]? *[:=\n][^,;]{8,})`),
-		regexp.MustCompile(`(?i)(['"_]?passphrase['"]? *[:=\n][^,;]{8,})`),
-		regexp.MustCompile(`(<[^(><.)]?password[^(><.)]*?>[^(><.)]+</[^(><.)]?password[^(><.)]*?>)`),
-		regexp.MustCompile(`(<[^(><.)]?passphrase[^(><.)]*?>[^(><.)]+</[^(><.)]?passphrase[^(><.)]*?>)`),
 		regexp.MustCompile(`(?i)(<ConsumerKey>\S*</ConsumerKey>)`),
 		regexp.MustCompile(`(?i)(<ConsumerSecret>\S*</ConsumerSecret>)`),
 		regexp.MustCompile(`(?i)(AWS[ \w]+key[ \w]+[:=])`),

--- a/talismanrc/.talismanrc
+++ b/talismanrc/.talismanrc
@@ -1,0 +1,5 @@
+fileignoreconfig:
+- filename: Foo
+  checksum: SomeCheckSum
+  ignore_detectors: []
+scopeconfig: []


### PR DESCRIPTION
Closes Issue #185 
* Refactored the regex code to add checks for any string preceding or succeeding the passphrases (password|passphrase|pwd|pword|pass)
* Added checks for new passphrases (secret|key) to the above list
* Reduced possible false positives for 'pw', since it is too short, by introducing a specific patter to look for
* Added tests for the above, including negative scenarios

Note: Have not considered that the following tests should pass, because adding this logic will not let talisman remain tech stack agnostic
`setPassword("12345678")` and `setenv(password, "12345678")`