### PR TITLE
Adding feature to ignore patterns/keywords

### DIFF
--- a/detector/pattern/pattern_detector.go
+++ b/detector/pattern/pattern_detector.go
@@ -86,9 +86,9 @@ func processAllowedPatterns(addition gitrepo.Addition, tRC *talismanrc.TalismanR
 	}
 
 	// Processing allowed patterns based on file path
-	for k, v := range tRC.FileIgnoreConfig {
-		if v.FileName == string(addition.Path) {
-			for _, pattern := range v.AllowedPatterns {
+	for _, fileignoreconfig := range tRC.FileIgnoreConfig {
+		if fileignoreconfig.FileName == string(addition.Path) {
+			for _, pattern := range fileignoreconfig.AllowedPatterns {
 				addition.Data = []byte(replaceAllStrings(string(addition.Data), pattern))
 			}
 		}

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -52,7 +52,7 @@ func TestShouldIgnorePasswordPatterns(t *testing.T) {
 	content := []byte("\"password\" : UnsafePassword")
 	filename := "secret.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	fileIgnoreConfig := talismanrc.FileIgnoreConfig{filename, "833b6c24c8c2c5c7e1663226dc401b29c005492dc76a1150fc0e0f07f29d4cc3", []string{"filecontent"}}
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{filename, "833b6c24c8c2c5c7e1663226dc401b29c005492dc76a1150fc0e0f07f29d4cc3", []string{"filecontent"}, []string{}}
 	ignores := &talismanrc.TalismanRC{FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig}}
 
 	NewPatternDetector(customPatterns).Test(helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanrc.NewTalismanRC(nil)), additions, ignores, results)

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -29,6 +29,7 @@ type FileIgnoreConfig struct {
 	FileName        string   `yaml:"filename"`
 	Checksum        string   `yaml:"checksum"`
 	IgnoreDetectors []string `yaml:"ignore_detectors,omitempty"`
+	AllowedPatterns []string `yaml:"allowed_patterns,omitempty"`
 }
 
 type ScopeConfig struct {
@@ -45,6 +46,7 @@ type TalismanRC struct {
 	FileIgnoreConfig []FileIgnoreConfig `yaml:"fileignoreconfig,omitempty"`
 	ScopeConfig      []ScopeConfig      `yaml:"scopeconfig,omitempty"`
 	CustomPatterns   []PatternString    `yaml:"custom_patterns,omitempty"`
+	AllowedPatterns  []string           `yaml:"allowed_patterns,omitempty"`
 	Experimental     ExperimentalConfig `yaml:"experimental,omitempty"`
 }
 

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -60,7 +60,7 @@ func TestIgnoringDetectors(t *testing.T) {
 
 func TestAddIgnoreFiles(t *testing.T) {
 	talismanRCConfig := CreatetalismanRCWithScopeIgnore([]string{})
-	talismanRCConfig.AddFileIgnores([]FileIgnoreConfig{FileIgnoreConfig{"Foo", "SomeCheckSum", []string{}}})
+	talismanRCConfig.AddFileIgnores([]FileIgnoreConfig{FileIgnoreConfig{"Foo", "SomeCheckSum", []string{}, []string{}}})
 	talismanRCConfig = Get()
 	assert.Equal(t, 1, len(talismanRCConfig.FileIgnoreConfig))
 }


### PR DESCRIPTION
Based on user feedback where Talisman was detecting some keyword frequently used like `key`, I decided to look at the source code to see if we can add an allowed list of patterns/keywords to avoid having users ignoring file content detector for example.

This appears to be a feature that other Talisman users are also interested to have if I refer to issue #39.

Based on [this comment](https://github.com/thoughtworks/talisman/issues/39#issuecomment-503553613), I added the feature to allow keyword at the repository level and also at the file level.

`.talismanrc` file can now look like this:

```
fileignoreconfig:
- filename: test
  checksum: 340a057ace3d476d4a4feb8f6e3f84d6b9ca5bf8963a20d2ebe29be3f51297d5
  ignore_detectors: []
  allowed_patterns: [key, pass]
scopeconfig: []
allowed_patterns:
- key
- pass
```

Please let me know what you think of this MVP version of the feature. I can improve it based on your feedback and add unit tests too.