### PR TITLE
Allow Keyword - PR #213 followup

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,13 +290,29 @@ At the moment, you can ignore
 * `filename`
 * `filesize`
 
+### Ignoring specific keywords
+
+Because some of your files might contain keywords such as `key` or `pass` that are not necessarily related to secrets, you might want to ignore these keywords to reduce the number of false positives.
+This can be achieved by using the `allowed_patterns` field at the file level and/or at the repository level:
+
+```yaml
+fileignoreconfig:
+- filename: test
+  allowed_patterns: [key]
+allowed_patterns:
+- keyword
+- pass
+```
+
+In the previous example, `key` is allowed in the `test` file, `keyword` and `pass` are allowed at the repository level.
+
 ### Ignoring multiple files of same type (with wildcards)
 
 You can choose to ignore all files of a certain type, because you know they will always be safe, and you wouldn't want Talisman to scan them.
 
 Steps:
 
-1. Format a wildard pattern for the files you want to ignore. For example, `*.lock`
+1. Format a wildcard pattern for the files you want to ignore. For example, `*.lock`
 2. Use the [checksum calculator](#checksum-calculator) to feed the pattern and attain a collective checksum. For example, `talisman --checksum="*.lock" `
 3. Copy the fileconfig block, printed on console, to .talismanrc file.
 

--- a/detector/pattern/pattern_detector.go
+++ b/detector/pattern/pattern_detector.go
@@ -76,7 +76,7 @@ func (detector PatternDetector) Test(comparator helpers.ChecksumCompare, current
 
 func replaceAllStrings(str string, pattern string) string {
 	re := regexp.MustCompile(fmt.Sprintf("(?i)%s", pattern))
-	return re.ReplaceAllString(str, "TALISMAN_ALLOWED_PATTERN")
+	return re.ReplaceAllString(str, "")
 }
 
 func processAllowedPatterns(addition gitrepo.Addition, tRC *talismanrc.TalismanRC) string {

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -59,6 +59,18 @@ func TestShouldIgnorePasswordPatterns(t *testing.T) {
 	assert.True(t, results.Successful(), "Expected file %s to be ignored by pattern", filename)
 }
 
+func TestShouldIgnoreAllowedPattern(t *testing.T) {
+	results := helpers.NewDetectionResults()
+	content := []byte("\"key\" : \"This is an allowed keyword\"\npassword=y0uw1lln3v3rgu3ssmyP@55w0rd")
+	filename := "allowed_pattern.txt"
+	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{filename, "", []string{}, []string{"key"}}
+	ignores := &talismanrc.TalismanRC{FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig}, AllowedPatterns: []string{"password"}}
+
+	NewPatternDetector(customPatterns).Test(helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanrc.NewTalismanRC(nil)), additions, ignores, results)
+	assert.True(t, results.Successful(), "Expected keywords %s to be ignored by Talisman", append(fileIgnoreConfig.AllowedPatterns, ignores.AllowedPatterns...))
+}
+
 func DetectionOfSecretPattern(filename string, content []byte) (*helpers.DetectionResults, []gitrepo.Addition, string) {
 	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -27,7 +27,7 @@ var (
 
 type FileIgnoreConfig struct {
 	FileName        string   `yaml:"filename"`
-	Checksum        string   `yaml:"checksum"`
+	Checksum        string   `yaml:"checksum,omitempty"`
 	IgnoreDetectors []string `yaml:"ignore_detectors,omitempty"`
 	AllowedPatterns []string `yaml:"allowed_patterns,omitempty"`
 }


### PR DESCRIPTION
This is to follow up on https://github.com/thoughtworks/talisman/pull/213

- I have updated the README
- I added a Test for allowed pattern at the file and repository level
- I have updated the string used to replace allowed keywords
- I added `omitempty` option on FileIgnoreConfig.Checksum as I believe this is not a required parameter (This might need additional testing 👀 cc @svishwanath-tw @harinee )