### PR TITLE
Grep-ing on more specific location string to fix auto-upgrade

### DIFF
--- a/global_install_scripts/talisman_hook_script.bash
+++ b/global_install_scripts/talisman_hook_script.bash
@@ -47,7 +47,7 @@ esac
 
 function check_and_upgrade_talisman_binary() {
 	if [ -n "${TALISMAN_HOME:-}" ]; then
-		LATEST_VERSION=$(curl -Is https://github.com/${ORG_REPO}/releases/latest | grep -E "Location" | grep -o '[^/]\+$' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+		LATEST_VERSION=$(curl -Is https://github.com/${ORG_REPO}/releases/latest | grep -iE "^location:" | grep -o '[^/]\+$' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 		CURRENT_VERSION=$(${TALISMAN_BINARY} --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 		if [ ! -z "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
 			echo ""


### PR DESCRIPTION
The regex looking for the latest tag was looking for string 'Location', whereas the actual string return in response is 'location'.

* grep will now look for case insensitive string
* appended a semi-colon in the string to reduce the scope of search
* included ^ to the string to look for exact header 'location'

Fixes #221