### PR TITLE
Fix for a case of Arbitrary File Overwrite while scanning malicious repo

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -39,7 +39,9 @@ func GenerateReport(r *helpers.DetectionResults, directory string) (path string,
 			return "", fmt.Errorf("error copying reports: %v", err)
 		}
 	} else {
-		path = filepath.Join(directory, "talisman_reports", "/data")
+		path = filepath.Join(directory, "talisman_reports")
+		_ = os.RemoveAll(path)
+		path = filepath.Join(path, "data")
 		jsonFilePath = filepath.Join(path, jsonFileName)
 	}
 


### PR DESCRIPTION
**Describe the bug**
Talisman doesn't verifies if _talisman_reports/data/report.json_ is a symlink and happily writes the report to the symlinked file thus overwriting the file. If a user scans a malicious repository with report.json symlinked to some file outside repo it will be overwritten.

**To Reproduce**
Steps to reproduce the behavior:
1. Execute echo 123 > /tmp/data
2. Scan a repo with talisman_reports/data/report.json symlinked to /tmp/data
3. Run talisman -s
4. Observe content of /tmp/data

**Expected behavior**
Should not follow symlink for _talisman_reports/data/report.json_ inside repo

**Desktop (please complete the following information):**
 - OS: Any?