### PR TITLE
Removing Interactive Mode for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ fileignoreconfig:
 Entering this in the `.talismanrc` file will ensure that Talisman will ignore the `danger.pem` file as long as the checksum matches the value mentioned in the `checksum` field.
 
 ### Interactive mode
+
+**Available only for non-Windows users**
+
 If it is too much of a hassle to keep copying content to .talismanrc everytime you encounter an error from Talisman, you could enable the interactive mode and let Talisman assist you in prompting the additions of the files to ignore. 
 Just follow the simple steps:
 1. Open your bash profile where your environment variables are set (.bashrc, .bash_profile, .profile or any other location)

--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"talisman/detector/severity"
 	"talisman/gitrepo"
@@ -315,7 +316,7 @@ func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext p
 		entriesToAdd = append(entriesToAdd, fileIgnoreConfig)
 	}
 
-	if promptContext.Interactive {
+	if promptContext.Interactive && runtime.GOOS != "windows" {
 		confirmedEntries := getUserConfirmation(entriesToAdd, promptContext)
 		talismanrc.Get().AddFileIgnores(confirmedEntries)
 	} else {


### PR DESCRIPTION
Users were getting blocked on Windows because Interactive mode was never really thought through properly for Windows shells. Removing the feature for Windows users for now, until we make it bug-free.

* Interactive mode will not be available for Windows users (see #228 on how users are blocked)
* Updated Readme to mention this change
* Refactored code in install script to use one way to determine the OS