### PR TITLE
Set interactive or debug mode only if variables are set to true

### DIFF
--- a/global_install_scripts/talisman_hook_script.bash
+++ b/global_install_scripts/talisman_hook_script.bash
@@ -26,6 +26,10 @@ function echo_success() {
 	echo -ne $(tput sgr0)
 }
 
+function toLower(){
+	echo "$1" | awk '{print tolower($0)}'
+}
+
 declare HOOKNAME="pre-commit"
 NAME=$(basename $0)
 ORG_REPO=${ORG_REPO:-'thoughtworks/talisman'}
@@ -73,9 +77,9 @@ if [[ -f .talisman_skip || -f .talisman_skip.${HOOKNAME} ]]; then
 fi
 
 DEBUG_OPTS=""
-[[ -n "${TALISMAN_DEBUG}" ]] && DEBUG_OPTS="-d"
+[[ $(toLower "${TALISMAN_DEBUG}") == "true" ]] && DEBUG_OPTS="-d"
 INTERACTIVE=""
-[[ -n "${TALISMAN_INTERACTIVE}" ]] && INTERACTIVE="-i"
+[[ $(toLower "${TALISMAN_INTERACTIVE}") == "true" ]] && INTERACTIVE="-i"
 
 CMD="${TALISMAN_BINARY} ${DEBUG_OPTS} --githook ${HOOKNAME} ${INTERACTIVE}"
 echo_debug "ARGS are $@"


### PR DESCRIPTION
The -n option only checks whether the variable is non-empty. So if someone were to set TALISMAN_INTERACTIVE to false and run the pre-commit hook, it will still enter into interactive mode. This MR is to make sure interactive mode is set only when TALISMAN_INTERACTIVE is explicitly set to true.