### PR TITLE
Disable tty pass through to talisman binary in pre-push hook mode

### DIFF
--- a/global_install_scripts/talisman_hook_script.bash
+++ b/global_install_scripts/talisman_hook_script.bash
@@ -1,6 +1,5 @@
 #!/bin/bash
 shopt -s extglob
-exec < /dev/tty
 
 # set TALISMAN_DEBUG="some-non-empty-value" in the env to get verbose output when the hook or talisman is running
 function echo_debug() {
@@ -75,7 +74,10 @@ fi
 DEBUG_OPTS=""
 [[ -n "${TALISMAN_DEBUG}" ]] && DEBUG_OPTS="-d"
 INTERACTIVE=""
-[[ -n "${TALISMAN_INTERACTIVE}" ]] && INTERACTIVE="-i"
+if [ -n "${TALISMAN_INTERACTIVE}" ]; then
+    INTERACTIVE="-i"
+	[[ "${HOOKNAME}" == "pre-commit" ]] && exec < /dev/tty || echo_warning "talisman pre-push hook cannot be invoked in interactive mode currently"
+fi
 
 CMD="${TALISMAN_BINARY} ${DEBUG_OPTS} --githook ${HOOKNAME} ${INTERACTIVE}"
 echo_debug "ARGS are $@"


### PR DESCRIPTION
The git refs sent via stdin to hook script are lost with `exec </dev/tty`