### PR TITLE
Use UPXv3.96 (latest) for binaries

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -23,7 +23,7 @@ fileignoreconfig:
   checksum: 7e5442d7ee07a6fad12cf636c5dc2880c69b9593fd286e44d567e178ffdd0194
 - filename: global_install_scripts/install.bash
   checksum: 5d659125ecbe619ea99f5bc71c2d761b586ce3ec9ccab7683ee54f4ebde9f748
-- filename: build
-  checksum: 8fbb878aeef148b198e747f24c38561492bc8b1290a1495470c61a6b9a90d5d7
+- filename: upx_compress.sh
+  checksum: 1a5d9b0ebd627646650c86236f4a21df5b4a2bcf26d77c439dd81c7b28ff9aa0
 scopeconfig:
 - scope: go

--- a/.talismanrc
+++ b/.talismanrc
@@ -23,5 +23,7 @@ fileignoreconfig:
   checksum: 7e5442d7ee07a6fad12cf636c5dc2880c69b9593fd286e44d567e178ffdd0194
 - filename: global_install_scripts/install.bash
   checksum: 5d659125ecbe619ea99f5bc71c2d761b586ce3ec9ccab7683ee54f4ebde9f748
+- filename: build
+  checksum: 8fbb878aeef148b198e747f24c38561492bc8b1290a1495470c61a6b9a90d5d7
 scopeconfig:
 - scope: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ go:
 - stable
 before_install:
 - go get github.com/mattn/goveralls
-- sudo apt-get -y install upx-ucl
 install: true
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - go mod vendor
     - go test -covermode=count -coverprofile=coverage.out -v ./...
     - "$GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci"
-before_deploy: "./build"
+before_deploy: "./build && ./upx_compress.sh"
 deploy:
   provider: releases
   draft: true

--- a/build
+++ b/build
@@ -4,4 +4,5 @@ export GO111MODULE=on
 go get github.com/mitchellh/gox
 gox -os="linux darwin windows" -arch="386 amd64" -ldflags="-s -w -X main.Version=${VERSION}"
 upx --lzma talisman_{l,d,w}*
+upx -t talisman_{l,d,w}*
 shasum -b -a256 talisman_{l,d,w}* > checksums

--- a/build
+++ b/build
@@ -3,13 +3,4 @@ VERSION=$(git describe --tags HEAD)
 export GO111MODULE=on
 go get github.com/mitchellh/gox
 gox -os="linux darwin windows" -arch="386 amd64" -ldflags="-s -w -X main.Version=${VERSION}"
-# UPX Install START
-# Install UPX 3.96(Latest for linux) working version
-wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
-sha256sum upx-3.96-amd64_linux.tar.xz | grep -i 'AC75F5172C1C530D1B5CE7215CA9E94586C07B675A26AF3B97F8421B8B8D413D' || exit -1
-tar -xf upx-3.96-amd64_linux.tar.xz
-PATH="$PATH:`pwd`/upx-3.96-amd64_linux"
-# UPX Install END
-upx --lzma talisman_{l,d,w}*
-upx -t talisman_{l,d,w}*
 shasum -b -a256 talisman_{l,d,w}* > checksums

--- a/build
+++ b/build
@@ -3,6 +3,13 @@ VERSION=$(git describe --tags HEAD)
 export GO111MODULE=on
 go get github.com/mitchellh/gox
 gox -os="linux darwin windows" -arch="386 amd64" -ldflags="-s -w -X main.Version=${VERSION}"
+# UPX Install START
+# Install UPX 3.96(Latest for linux) working version
+wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+sha256sum upx-3.96-amd64_linux.tar.xz | grep -i 'AC75F5172C1C530D1B5CE7215CA9E94586C07B675A26AF3B97F8421B8B8D413D' || exit -1
+tar -xf upx-3.96-amd64_linux.tar.xz
+PATH="$PATH:`pwd`/upx-3.96-amd64_linux"
+# UPX Install END
 upx --lzma talisman_{l,d,w}*
 upx -t talisman_{l,d,w}*
 shasum -b -a256 talisman_{l,d,w}* > checksums

--- a/upx_compress.sh
+++ b/upx_compress.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# UPX Install START
+# Install UPX 3.96(Latest for linux) working version
+wget https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz
+sha256sum upx-3.96-amd64_linux.tar.xz | grep -i 'AC75F5172C1C530D1B5CE7215CA9E94586C07B675A26AF3B97F8421B8B8D413D' || exit -1
+tar -xf upx-3.96-amd64_linux.tar.xz
+PATH="$PATH:`pwd`/upx-3.96-amd64_linux"
+# UPX Install END
+upx --lzma talisman_{l,d,w}*
+upx -t talisman_{l,d,w}*
+shasum -b -a256 talisman_{l,d,w}* > checksums


### PR DESCRIPTION
None of 

 https://launchpad.net/ubuntu/xenial/amd64/upx-ucl/ 
 https://launchpad.net/ubuntu/bionic/amd64/upx-ucl/ 
 https://launchpad.net/ubuntu/eoan/amd64/upx-ucl/ 
 https://launchpad.net/ubuntu/focal/amd64/upx-ucl/ 

have the latest release of UPX and all have different versions of UPX, as a workaround modified the script to download UPX v3.96(current latest release) and apparently stable for our binary targets. 

Added a step `upx -t` as a additional check.

Should solve https://github.com/thoughtworks/talisman/issues/242