### PR TITLE
Show hook trigger message

### DIFF
--- a/talisman.go
+++ b/talisman.go
@@ -82,6 +82,7 @@ func main() {
 			fmt.Println(fmt.Errorf("githook should be %s or %s, but got %s", PreCommit, PrePush, githook))
 			os.Exit(1)
 		}
+		fmt.Printf("Talisman %s %s hook tiggered\n", Version, githook)
 	}
 
 	_options := options{


### PR DESCRIPTION
Displays a line on console to be sure if Talisman has been triggered or not else maybe user can't be sure if there was not a secret or talisman didn't got triggered. 

**For scenario where PRE-\* HOOKS are messed up or missing** 

![verbose](https://user-images.githubusercontent.com/40319304/92568129-55693680-f29c-11ea-9389-2393324e5a3a.JPG)

