### PR TITLE
[Issue #247] ♻️ remove dependency on talisman_hook_script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,27 +142,10 @@ run() {
 
     cat >"$REPO_HOOK_TARGET" <<EOF
 #!/bin/bash
-function echo_debug() {
-	MSG="\$@"
-	[[ -n "\${TALISMAN_DEBUG}" ]] && echo "\${MSG}"
-}
-
-function toLower(){
-	echo "\$1" | awk '{print tolower(\$0)}'
-}
-
-# Don't run talisman checks in a git repo, if we find a .talisman_skip or .talisman_skip.pre-<commit/push> file in the repo
-if [[ -f .talisman_skip || -f .talisman_skip.${HOOK_NAME} ]]; then
-	echo_debug "Found skip file. Not performing checks"
-	exit 0
-fi
-
-DEBUG_OPTS=""
-[[ \$(toLower "\${TALISMAN_DEBUG}") == "true" ]] && DEBUG_OPTS="-d"
-
+[[ -n "\${TALISMAN_DEBUG}" ]] && DEBUG_OPTS="-d"
 CMD="${PWD}/${TALISMAN_BIN_TARGET} \${DEBUG_OPTS} --githook ${HOOK_NAME}"
-echo_debug "ARGS are \$@"
-echo_debug "Executing: \${CMD}"
+[[ -n "\${TALISMAN_DEBUG}" ]] && echo "ARGS are \$@"
+[[ -n "\${TALISMAN_DEBUG}" ]] && echo "Executing: \${CMD}"
 \${CMD}
 EOF
     chmod +x "$REPO_HOOK_TARGET"


### PR DESCRIPTION
Changes affecting `install.sh` (script used to install talisman to a single repo, not to be confused with `global_install_scripts/install.bash` ):
- #247 
  - remove dependency on talisman_hook_script
  - refactor heredoc hook script to minimise complexity

I refined my original solution because it would be better if this just used the features it actually needed from `talisman_hook_script` instead of depending on the entire script