### PR TITLE
Fix Windows specific bug for talismanrc functionality

### DIFF
--- a/gitrepo/gitrepo.go
+++ b/gitrepo/gitrepo.go
@@ -191,9 +191,9 @@ func (repo GitRepo) CheckIfFileExists(fileName string) bool {
 //If there is no path separator anywhere in the pattern, the pattern is matched against the base name of the file. Thus, the pattern will match files with that name anywhere in the repository.
 func (a Addition) Matches(pattern string) bool {
 	var result bool
-	if pattern[len(pattern)-1] == os.PathSeparator {
+	if pattern[len(pattern)-1] == '/' {
 		result = strings.HasPrefix(string(a.Path), pattern)
-	} else if strings.ContainsRune(pattern, os.PathSeparator) {
+	} else if strings.ContainsRune(pattern, '/') {
 		result, _ = path.Match(pattern, string(a.Path))
 	} else {
 		result, _ = path.Match(pattern, string(a.Name))


### PR DESCRIPTION
https://github.com/thoughtworks/talisman/issues/256 

https://github.com/thoughtworks/talisman/blob/0855689c3744d15383b8ed0aeccadff90a2a9272/gitrepo/gitrepo.go#L194-L200

Details - Suppose .talismanrc has a exclusion as 

folder2/ (True for Line 194)
folder1/file.pem (True for Line 196)


the code fragment works fine on Linux and Darwin as os.PathSeparator in line 194 and 196 return '/'

On Windows Git still uses '/' as PathSeparator (unexpected) but GOlang uses os.PathSeparator  as  '\\'
![git_pathSeparator_windows](https://user-images.githubusercontent.com/40319304/92893873-b4af7e00-f437-11ea-9b7b-fa6e1b7a2e49.JPG)


On Windows os.PathSeparator  returns '\\' because of which any path with '/' on windows will never be true for line 194 https://github.com/thoughtworks/talisman/blob/0855689c3744d15383b8ed0aeccadff90a2a9272/gitrepo/gitrepo.go#L194 and 196 https://github.com/thoughtworks/talisman/blob/0855689c3744d15383b8ed0aeccadff90a2a9272/gitrepo/gitrepo.go#L196 and will fall to else branch in line 198
https://github.com/thoughtworks/talisman/blob/0855689c3744d15383b8ed0aeccadff90a2a9272/gitrepo/gitrepo.go#L198
i.e. if .talismanrc has exclusion for file.pem on windows it will match
file.pem
folder1/file.pem
folder1/folder2/file.pem