### PR TITLE
Add Windows compatibility for single-project install using `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,11 +164,12 @@ run() {
 
     cat >"$REPO_HOOK_TARGET" <<EOF
 #!/bin/bash
-[[ -n "\${TALISMAN_DEBUG}" ]] && TALISMAN_DEBUG_OPTS="-d"
-CMD="${PWD}/${TALISMAN_BIN_TARGET} \${TALISMAN_DEBUG_OPTS} --githook ${HOOK_NAME}"
+TALISMAN_OPTS="--githook ${HOOK_NAME}"
+[[ -n "\${TALISMAN_DEBUG}" ]] && TALISMAN_OPTS="-d \${TALISMAN_OPTS}"
+TALISMAN_BIN="${PWD}/${TALISMAN_BIN_TARGET}"
 [[ -n "\${TALISMAN_DEBUG}" ]] && echo "ARGS are \$@"
-[[ -n "\${TALISMAN_DEBUG}" ]] && echo "Executing: \${CMD}"
-\${CMD}
+[[ -n "\${TALISMAN_DEBUG}" ]] && echo "Executing: \${TALISMAN_BIN} \${TALISMAN_OPTS}"
+"\$TALISMAN_BIN" \$TALISMAN_OPTS
 EOF
     chmod +x "$REPO_HOOK_TARGET"
 


### PR DESCRIPTION
Changes affecting install.sh (script used to install talisman to a single repo, not to be confused with global_install_scripts/install.bash ):

 #198 
-  add SHAs and OS detection for Windows to download windows binaries
-  correctly quote binary paths

Outstanding issues (existed before this PR):
- global install using `install.sh` is broken on Windows
- https://github.com/thoughtworks/talisman/issues/260 you need to update the version number and SHA each time Talisman updates
