### PR TITLE
Changed mechanisms for single repo installation

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -27,5 +27,7 @@ fileignoreconfig:
   checksum: 1a5d9b0ebd627646650c86236f4a21df5b4a2bcf26d77c439dd81c7b28ff9aa0
 - filename: install.sh
   checksum: 871261b64e3321d1e15c02e7fcb84b7f31ff18dabd7b8d6459d8c1f6fc443c3a
+- filename: install.sh
+  checksum: c909f6a1caefba3f196d489f9262608044be596a44793c2173ec55b98ecec649
 scopeconfig:
 - scope: go

--- a/global_install_scripts/talisman_hook_script.bash
+++ b/global_install_scripts/talisman_hook_script.bash
@@ -54,7 +54,7 @@ function check_and_upgrade_talisman_binary() {
 		LATEST_VERSION=$(curl --connect-timeout $TALISMAN_UPGRADE_CONNECT_TIMEOUT -Is https://github.com/${ORG_REPO}/releases/latest | grep -iE "^location:" | grep -o '[^/]\+$' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 		CURRENT_VERSION=$(${TALISMAN_BINARY} --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 		if [ -z "$LATEST_VERSION" ]; then
-			echo_warning "Failed to retrieve latest version, skipping update."
+			echo_warning "Failed to retrieve latest Talisman version, skipping update."
 		elif [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
 			echo ""
 			echo_warning "Your version of Talisman is outdated. Updating Talisman to v${LATEST_VERSION}"

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@
 
 set -euo pipefail
 
+DEBUG=${DEBUG:-''}
 HOOK_NAME="${1:-pre-push}"
 case "$HOOK_NAME" in
 pre-commit | pre-push) REPO_HOOK_TARGET=".git/hooks/${HOOK_NAME}" ;;
@@ -20,22 +21,21 @@ esac
 # user runs with curl|bash and curl fails in the middle of the download
 # (https://www.seancassidy.me/dont-pipe-to-your-shell.html)
 run() {
+  declare TALISMAN_BINARY_NAME
+
   IFS=$'\n'
 
   VERSION="v1.8.0"
   GITHUB_URL="https://github.com/thoughtworks/talisman"
-  BINARY_BASE_URL="$GITHUB_URL/releases/download/$VERSION/talisman"
+  BINARY_BASE_URL="$GITHUB_URL/releases/download/$VERSION"
   REPO_HOOK_BIN_DIR=".git/hooks/bin"
 
   DEFAULT_GLOBAL_TEMPLATE_DIR="$HOME/.git-templates"
 
-  EXPECTED_BINARY_SHA_LINUX_AMD64="22b1aaee860b27306bdf345a0670f138830bcf7fbe16c75be186fe119e9d54b4"
-  EXPECTED_BINARY_SHA_LINUX_X86="d0558d626a4ee1e90d2c2a5f3c69372a30b8f2c8e390a59cedc15585b0731bc4"
-  EXPECTED_BINARY_SHA_DARWIN_AMD64="f30e1ec6fb3e1fc33928622f17d6a96933ca63d5ab322f9ba869044a3075ffda"
-  EXPECTED_BINARY_SHA_WINDOWS_AMD64="697cebb5988ee002b630b814c6c6f5d49d921c9c3aad4545c4a77d749e5ae833"
-  EXPECTED_BINARY_SHA_WINDOWS_X86="98ee5ed4bb394096a643531b7b8d3e6e919cc56e4673add744b46036260527c3"
-
   declare DOWNLOADED_BINARY
+  TEMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'talisman_setup')
+	trap "rm -r ${TEMP_DIR}" EXIT
+	chmod 0700 ${TEMP_DIR}
 
   E_HOOK_ALREADY_PRESENT=1
   E_CHECKSUM_MISMATCH=2
@@ -49,14 +49,24 @@ run() {
     echo "$1" >&2
     echo -ne $(tput sgr0) >&2
   }
+  export -f echo_error
+
+	function echo_debug() {
+		[[ -z "${DEBUG}" ]] && return
+		echo -ne $(tput setaf 3) >&2
+		echo "$1" >&2
+		echo -ne $(tput sgr0) >&2
+	}
+	export -f echo_debug
 
   echo_success() {
     echo -ne $(tput setaf 2)
     echo "$1" >&2
     echo -ne $(tput sgr0)
   }
+  export -f echo_success
 
-  	function operating_system() {
+  operating_system() {
     OS=$(uname -s)
     case $OS in
       "Linux")
@@ -103,57 +113,33 @@ run() {
 		fi
   }
 
-  download_and_verify() {
-    if [[ ! -x "$(which curl 2>/dev/null)" ]]; then
-      echo_error "This script requires 'curl' to download the Talisman binary."
-      exit $E_DEPENDENCY_NOT_FOUND
-    fi
-    if [[ ! -x "$(which shasum 2>/dev/null)" ]]; then
-      echo_error "This script requires 'shasum' to verify the Talisman binary."
-      exit $E_DEPENDENCY_NOT_FOUND
-    fi
+	function download() {
+		OBJECT=$1
+		DOWNLOADED_BINARY="$TEMP_DIR/talisman"
+		DOWNLOAD_URL=${BINARY_BASE_URL}/${OBJECT}
+		echo "Downloading ${OBJECT} from ${DOWNLOAD_URL}"
+		curl --location --silent ${DOWNLOAD_URL} >${DOWNLOADED_BINARY}
+	}
 
-    echo 'Downloading and verifying binary...'
-    echo
+  function verify_checksum() {
+		FILE_NAME=$1
+		CHECKSUM_FILE_NAME='checksums'
+		echo_debug "Verifying checksum for ${FILE_NAME}"
+		download ${CHECKSUM_FILE_NAME}
 
-    TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'talisman')
-    trap 'rm -r $TMP_DIR' EXIT
-    chmod 0700 $TMP_DIR
+		pushd ${TEMP_DIR} >/dev/null 2>&1
+		grep ${TALISMAN_BINARY_NAME} ${CHECKSUM_FILE_NAME} >${CHECKSUM_FILE_NAME}.single
+		shasum -a 256 -c ${CHECKSUM_FILE_NAME}.single
+		popd >/dev/null 2>&1
+		echo_debug "Checksum verification successful!"
+		echo
+	}
 
-    ARCH_SUFFIX=$(binary_arch_suffix)
-
-    curl --location --silent "${BINARY_BASE_URL}_${ARCH_SUFFIX}" >"${TMP_DIR}/talisman"
-
-    DOWNLOAD_SHA=$(shasum -b -a256 "${TMP_DIR}/talisman" | cut -d' ' -f1)
-
-    declare EXPECTED_BINARY_SHA
-    case "$ARCH_SUFFIX" in
-    linux_386)
-      EXPECTED_BINARY_SHA="$EXPECTED_BINARY_SHA_LINUX_X86"
-      ;;
-    linux_amd64)
-      EXPECTED_BINARY_SHA="$EXPECTED_BINARY_SHA_LINUX_AMD64"
-      ;;
-    darwin_amd64)
-      EXPECTED_BINARY_SHA="$EXPECTED_BINARY_SHA_DARWIN_AMD64"
-      ;;
-    windows_386)
-      EXPECTED_BINARY_SHA="$EXPECTED_BINARY_SHA_WINDOWS_X86"
-      ;;
-    windows_amd64)
-      EXPECTED_BINARY_SHA="$EXPECTED_BINARY_SHA_WINDOWS_AMD64"
-      ;;
-    esac
-
-    if [[ ! "$DOWNLOAD_SHA" == "$EXPECTED_BINARY_SHA" ]]; then
-      echo_error "Uh oh... SHA256 checksum did not verify. Binary download must have been corrupted in some way."
-      echo_error "Expected SHA: $EXPECTED_BINARY_SHA"
-      echo_error "Download SHA: $DOWNLOAD_SHA"
-      exit $E_CHECKSUM_MISMATCH
-    fi
-
-    DOWNLOADED_BINARY="$TMP_DIR/talisman"
-  }
+	function download_and_verify() {
+		binary_arch_suffix
+		download ${TALISMAN_BINARY_NAME}
+		verify_checksum ${TALISMAN_BINARY_NAME}
+	}
 
   install_to_repo() {
     if [[ -x "$REPO_HOOK_TARGET" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -115,10 +115,9 @@ run() {
 
 	function download() {
 		OBJECT=$1
-		DOWNLOADED_BINARY="$TEMP_DIR/talisman"
 		DOWNLOAD_URL=${BINARY_BASE_URL}/${OBJECT}
-		echo "Downloading ${OBJECT} from ${DOWNLOAD_URL}"
-		curl --location --silent ${DOWNLOAD_URL} >${DOWNLOADED_BINARY}
+		echo_debug "Downloading ${OBJECT} from ${DOWNLOAD_URL}"
+		curl --location --silent ${DOWNLOAD_URL} >"$TEMP_DIR/${OBJECT}"
 	}
 
   function verify_checksum() {
@@ -137,8 +136,9 @@ run() {
 
 	function download_and_verify() {
 		binary_arch_suffix
-		download ${TALISMAN_BINARY_NAME}
-		verify_checksum ${TALISMAN_BINARY_NAME}
+		download "${TALISMAN_BINARY_NAME}"
+		DOWNLOADED_BINARY="${TEMP_DIR}/${TALISMAN_BINARY_NAME}"
+		verify_checksum "${TALISMAN_BINARY_NAME}"
 	}
 
   install_to_repo() {

--- a/install.sh
+++ b/install.sh
@@ -25,8 +25,8 @@ run() {
 
   IFS=$'\n'
 
-  VERSION="v1.8.0"
   GITHUB_URL="https://github.com/thoughtworks/talisman"
+  VERSION=$(curl --silent "https://api.github.com/repos/thoughtworks/talisman/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
   BINARY_BASE_URL="$GITHUB_URL/releases/download/$VERSION"
   REPO_HOOK_BIN_DIR=".git/hooks/bin"
 

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ run() {
 	function download() {
 		OBJECT=$1
 		DOWNLOAD_URL=${BINARY_BASE_URL}/${OBJECT}
-		echo_debug "Downloading ${OBJECT} from ${DOWNLOAD_URL}"
+		echo "Downloading ${OBJECT} from ${DOWNLOAD_URL}"
 		curl --location --silent ${DOWNLOAD_URL} >"$TEMP_DIR/${OBJECT}"
 	}
 
@@ -144,8 +144,9 @@ run() {
   install_to_repo() {
     if [[ -x "$REPO_HOOK_TARGET" ]]; then
       echo_error "Oops, it looks like you already have a ${HOOK_NAME} hook installed at '${REPO_HOOK_TARGET}'."
-      echo_error "Talisman is not compatible with other hooks right now, sorry."
-      echo_error "If this is a problem for you, please open an issue: https://github.com/thoughtworks/talisman/issues/new"
+      echo_error "If this is expected, you should consider setting-up a tool to allow git hook chaining,"
+      echo_error "like pre-commit (brew install pre-commit) or Husky or any other tool of your choice."
+      echo_error "WARNING! Talisman hook not installed."
       exit $E_HOOK_ALREADY_PRESENT
     fi
 
@@ -218,8 +219,9 @@ EOF
 
     if [ -f "$TEMPLATE_DIR/hooks/${HOOK_NAME}" ]; then
       echo_error "Oops, it looks like you already have a ${HOOK_NAME} hook installed at '$TEMPLATE_DIR/hooks/${HOOK_NAME}'."
-      echo_error "Talisman is not compatible with other hooks right now, sorry."
-      echo_error "If this is a problem for you, please open an issue: https://github.com/thoughtworks/talisman/issues/new"
+				echo_error "If this is expected, you should consider setting-up a tool to allow git hook chaining,"
+				echo_error "like pre-commit (brew install pre-commit) or Husky or any other tool of your choice."
+				echo_error "WARNING! Talisman hook not installed."
       exit $E_HOOK_ALREADY_PRESENT
     fi
 


### PR DESCRIPTION
Following changes were made to the single repo installation script
* OS check is made to include Windows support
* Changed the checksum checks to the mechanism used in global installation. No more hard-coded checksums!
* Changed version check to always point to the latest tag. No more hard-coded version!