### PR TITLE
Stage updated .talismanrc file after Interactive Mode Prompt

### DIFF
--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"talisman/detector/severity"
@@ -319,6 +320,7 @@ func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext p
 	if promptContext.Interactive && runtime.GOOS != "windows" {
 		confirmedEntries := getUserConfirmation(entriesToAdd, promptContext)
 		talismanrc.Get().AddFileIgnores(confirmedEntries)
+		exec.Command("git", "add", ".talismanrc").CombinedOutput()
 	} else {
 		printTalismanIgnoreSuggestion(entriesToAdd)
 		return


### PR DESCRIPTION
Currently updated .talismanrc is not staged/added to commit but allows talisman to include ignores from it

![interactive_mode_git_add](https://user-images.githubusercontent.com/40319304/94764883-9f8b9680-03c8-11eb-80b3-e4dc22af1f31.JPG)
