### PR TITLE
Support for custom severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,20 @@ This will report all Medium severity issues and higher (Potential risks that are
 2. By default, the threshold is set to low.
 3. Any custom search patterns you add, are considered to be of high severity.
 
+## Configuring custom severities
+
+You can customize the [security levels](detector/severity/severity_config.go) of the detectors provided by Talisman in the .talismanrc file:
+
+```yaml
+custom_severities:
+- detector: Base64Content
+  severity: medium
+- detector: HexContent
+  severity: low
+```
+
+By using custom severities and a severity threshold, Talisman can be configured to alert only on what is important based on your context. This can be useful to reduce the number of false positives.
+
 ## Talisman as a CLI utility
 
 If you execute `talisman` on the command line, you will be able to view all the parameter options you can pass

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -26,6 +26,11 @@ var (
 	currentRCFileName  = DefaultRCFileName
 )
 
+type CustomSeverityConfig struct {
+	Detector        string `yaml:"detector"`
+	Severity        string `yaml:"severity"`
+}
+
 type FileIgnoreConfig struct {
 	FileName        string   `yaml:"filename"`
 	Checksum        string   `yaml:"checksum,omitempty"`
@@ -47,18 +52,20 @@ type TalismanRC struct {
 	FileIgnoreConfig []FileIgnoreConfig     `yaml:"fileignoreconfig,omitempty"`
 	ScopeConfig      []ScopeConfig          `yaml:"scopeconfig,omitempty"`
 	CustomPatterns   []PatternString        `yaml:"custom_patterns,omitempty"`
+	CustomSeverities []CustomSeverityConfig `yaml:"custom_severities,omitempty"`
 	AllowedPatterns  []string               `yaml:"allowed_patterns,omitempty"`
 	Experimental     ExperimentalConfig     `yaml:"experimental,omitempty"`
 	Threshold        severity.SeverityValue `default:"1" yaml:"threshold,omitempty"`
 }
 
 type TalismanRCFile struct {
-	FileIgnoreConfig []FileIgnoreConfig `yaml:"fileignoreconfig,omitempty"`
-	ScopeConfig      []ScopeConfig      `yaml:"scopeconfig,omitempty"`
-	CustomPatterns   []PatternString    `yaml:"custom_patterns,omitempty"`
-	AllowedPatterns  []string           `yaml:"allowed_patterns,omitempty"`
-	Experimental     ExperimentalConfig `yaml:"experimental,omitempty"`
-	Threshold        string             `default:"low" yaml:"threshold,omitempty"`
+	FileIgnoreConfig []FileIgnoreConfig     `yaml:"fileignoreconfig,omitempty"`
+	ScopeConfig      []ScopeConfig          `yaml:"scopeconfig,omitempty"`
+	CustomPatterns   []PatternString        `yaml:"custom_patterns,omitempty"`
+	CustomSeverities []CustomSeverityConfig `yaml:"custom_severities,omitempty"`
+	AllowedPatterns  []string               `yaml:"allowed_patterns,omitempty"`
+	Experimental     ExperimentalConfig     `yaml:"experimental,omitempty"`
+	Threshold        string                 `default:"low" yaml:"threshold,omitempty"`
 }
 
 func SetFs(_fs afero.Fs) {
@@ -103,6 +110,7 @@ func NewTalismanRC(fileContents []byte) *TalismanRC {
 		FileIgnoreConfig: talismanRCFile.FileIgnoreConfig,
 		ScopeConfig:      talismanRCFile.ScopeConfig,
 		CustomPatterns:   talismanRCFile.CustomPatterns,
+		CustomSeverities: talismanRCFile.CustomSeverities,
 		AllowedPatterns:  talismanRCFile.AllowedPatterns,
 		Experimental:     talismanRCFile.Experimental,
 		Threshold:        severity.SeverityStringToValue(talismanRCFile.Threshold),


### PR DESCRIPTION
This is a follow up of issue #277 where I was suggesting to change some default severities.

This PR allows users to change the severity level of the detectors by modifying the `.talismanrc` config file:

```yaml
custom_severities:
- detector: Base64Content
  severity: medium
- detector: HexContent
  severity: low
```
