### PR TITLE
Older windows support branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ a real git revision!)
     # -   id: talisman-push
 ```
 
+*Disclaimer: Talisman cannot guarantee its functionality in MicroSoft's unsupported versions of Windows. Anyway Taliman is successfully tested on Windows 7 and server 2008 R2, which might not work in future releases.*
 
 # Upgrading
 Since release v0.4.4, Talisman <b>automatically updates</b> the binary to the latest release, when the hook is invoked (at pre-commit/pre-push, as set up). So, just sit back, relax, and keep using the latest Talisman without any extra efforts.

--- a/global_install_scripts/install.bash
+++ b/global_install_scripts/install.bash
@@ -87,10 +87,10 @@ function run() {
 		"Darwin")
 			echo "darwin"
 			;;
-		MINGW32_NT-10.0-WOW*)
+		MINGW32_NT-*)
 			echo "windows"
 			;;
-		MINGW64_NT-10.0*)
+		MINGW64_NT-*)
 			echo "windows"
 			;;
 		*)

--- a/install.sh
+++ b/install.sh
@@ -75,13 +75,10 @@ run() {
       "Darwin")
         echo "darwin"
         ;;
-      MINGW32_NT-10.0-WOW*)
+      MINGW32_NT-*)
         echo "windows"
         ;;
-      MINGW64_NT-10.0*)
-        echo "windows"
-        ;;
-      MINGW64_NT-6.3*)
+      MINGW64_NT-*)
         echo "windows"
         ;;
       *)

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,9 @@ run() {
       MINGW64_NT-10.0*)
         echo "windows"
         ;;
+      MINGW64_NT-6.3*)
+        echo "windows"
+        ;;
       *)
         echo_error "Talisman currently only supports Windows, Linux and MacOS(darwin) systems."
         echo_error "If this is a problem for you, please open an issue: https://github.com/${INSTALL_ORG_REPO}/issues/new"


### PR DESCRIPTION
Current operating system check, will allow only windows 10, 11, server 2016 & 2019.
There are older versions supported OSs, which version number is not MINGW64_NT-10.0*. So, I removed version check and allowed to install in all versions windows OS.

I referred [this url](https://en.wikipedia.org/wiki/Comparison_of_Microsoft_Windows_versions), to verify different kernal versions in windows.