### PR TITLE
Add images scope for talismanrc ignore config

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,13 +367,14 @@ You can choose to ignore files by specifying the language scope for your project
 scopeconfig:
   - scope: go
   - scope: node
+  - scope: images
 ```
 
 Talisman is configured to ignore certain files based on the specified scope. For example, mentioning the node scope in the scopeconfig will prevent talisman from scanning files such as the yarn.lock or package-lock.json.
 
 You can specify multiple scopes.
 
-Currently .talismanrc only supports scopeconfig support for go and node. Other scopes will be added shortly.
+Currently .talismanrc only supports scopeconfig support for go, node and images. Other scopes will be added shortly.
 
 ### Custom search patterns
 

--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -1,6 +1,7 @@
 package talismanrc
 
 var knownScopes = map[string][]string{
-	"node": {"yarn.lock", "package-lock.json", "node_modules/"},
-	"go":   {"makefile", "go.mod", "go.sum", "Gopkg.toml", "Gopkg.lock", "glide.yaml", "glide.lock", "vendor/"},
+	"node":   {"yarn.lock", "package-lock.json", "node_modules/"},
+	"go":     {"makefile", "go.mod", "go.sum", "Gopkg.toml", "Gopkg.lock", "glide.yaml", "glide.lock", "vendor/"},
+	"images": {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 }

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -65,15 +65,19 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 	file3 := testAddition("java.lock")
 	file4 := testAddition("Gopkg.lock")
 	file5 := testAddition("vendors/abc")
-	additions := []gitrepo.Addition{file1, file2, file3, file4, file5}
+	file6 := testAddition("imgJpeg.jpeg")
+	file7 := testAddition("imgJpg.jpg")
+	file8 := testAddition("imgPng.png")
+	additions := []gitrepo.Addition{file1, file2, file3, file4, file5, file6, file7, file8}
 
-	scopesToIgnore := []string{"node", "go"}
+	scopesToIgnore := []string{"node", "go", "images"}
 	talismanRCConfig := createTalismanRCWithScopeIgnores(scopesToIgnore)
 
 	nodeIgnores := []string{"node.lock", "*yarn.lock"}
 	javaIgnores := []string{"java.lock"}
 	goIgnores := []string{"go.lock", "Gopkg.lock", "vendors/"}
-	scopesMap := map[string][]string{"node": nodeIgnores, "java": javaIgnores, "go": goIgnores}
+	imageIgnores := []string{"*.jpeg", "*.jpg", "*.png"}
+	scopesMap := map[string][]string{"node": nodeIgnores, "java": javaIgnores, "go": goIgnores, "images": imageIgnores}
 	knownScopes = scopesMap
 	filteredAdditions := talismanRCConfig.FilterAdditions(additions)
 
@@ -82,6 +86,9 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 	assert.Contains(t, filteredAdditions, file3)
 	assert.NotContains(t, filteredAdditions, file4)
 	assert.NotContains(t, filteredAdditions, file5)
+	assert.NotContains(t, filteredAdditions, file6)
+	assert.NotContains(t, filteredAdditions, file7)
+	assert.NotContains(t, filteredAdditions, file8)
 }
 
 func TestIgnoringDetectors(t *testing.T) {


### PR DESCRIPTION
Add images scope to ignore .jpeg, .jpg, .png, .tiff, .bmp from scans. 

This is to handle issue [#140](https://github.com/thoughtworks/talisman/issues/140)(Add permanent scope ignore for images) . 