### PR TITLE
Fix unbound variable error in global install script

### DIFF
--- a/global_install_scripts/install.bash
+++ b/global_install_scripts/install.bash
@@ -104,6 +104,7 @@ function run() {
 	function set_talisman_binary_name() {
 		# based on OS (linux/darwin) and ARCH(32/64 bit)
 		declare SUFFIX
+		declare OS
 		SUFFIX=$(operating_system)
 		ARCH=$(uname -m)
 		case $ARCH in


### PR DESCRIPTION
while installing talisman ran into this error : /tmp/install_talisman.bash: line 127: OS: unbound variable