### PR TITLE
Checksum fix

### DIFF
--- a/checksumcalculator/checksumcalculator_test.go
+++ b/checksumcalculator/checksumcalculator_test.go
@@ -1,15 +1,21 @@
 package checksumcalculator
 
 import (
-	"github.com/stretchr/testify/assert"
 	"talisman/gitrepo"
 	"talisman/utility"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+var defaultSHA256Hasher utility.SHA256Hasher
+
+func init() {
+	defaultSHA256Hasher = utility.MakeHasher("default", ".")
+}
 
 func TestNewChecksumCalculator(t *testing.T) {
 	t.Run("should return empty CollectiveChecksum when non existing file name pattern is sent", func(t *testing.T) {
-		defaultSHA256Hasher := utility.DefaultSHA256Hasher{}
 		gitAdditions := []gitrepo.Addition{
 			{
 				Path: "GitRepoPath1",
@@ -26,7 +32,6 @@ func TestNewChecksumCalculator(t *testing.T) {
 	})
 
 	t.Run("should return  CollectiveChecksum when existing file name pattern is sent", func(t *testing.T) {
-		defaultSHA256Hasher := utility.DefaultSHA256Hasher{}
 		gitAdditions := []gitrepo.Addition{
 			{
 				Path: "GitRepoPath1",
@@ -45,7 +50,6 @@ func TestNewChecksumCalculator(t *testing.T) {
 
 func TestDefaultChecksumCalculator_SuggestTalismanRC(t *testing.T) {
 	t.Run("should return no suggestion for .talismanrc format when no matching file name patterns is sent", func(t *testing.T) {
-		defaultSHA256Hasher := utility.DefaultSHA256Hasher{}
 		gitAdditions := []gitrepo.Addition{
 			{
 				Path: "GitRepoPath1",
@@ -65,7 +69,6 @@ func TestDefaultChecksumCalculator_SuggestTalismanRC(t *testing.T) {
 	})
 
 	t.Run("should return suggestion for .talismanrc format when matching file name patterns is sent", func(t *testing.T) {
-		defaultSHA256Hasher := utility.DefaultSHA256Hasher{}
 		gitAdditions := []gitrepo.Addition{
 			{
 				Path: "GitRepoPath1",

--- a/cmd/acceptance_test.go
+++ b/cmd/acceptance_test.go
@@ -310,7 +310,7 @@ func runTalisman(git *git_testing.GitTesting) int {
 	prompter := prompt.NewPrompt()
 	promptContext := prompt.NewPromptContext(false, prompter)
 	if options.GitHook == PrePush {
-		options.Input = mockStdIn(git.EarliestCommit(), git.LatestCommit())
+		talismanInput = mockStdIn(git.EarliestCommit(), git.LatestCommit())
 	}
 	return run(promptContext)
 }

--- a/cmd/acceptance_test.go
+++ b/cmd/acceptance_test.go
@@ -298,7 +298,7 @@ func TestIgnoreHistoryDetectsExistingIssuesOnHead(t *testing.T) {
 }
 
 func runTalismanInPrePushMode(git *git_testing.GitTesting) int {
-	options.Debug = false
+	options.Debug = true
 	options.GitHook = PrePush
 	return runTalisman(git)
 }

--- a/cmd/acceptance_test.go
+++ b/cmd/acceptance_test.go
@@ -155,16 +155,16 @@ func TestShouldExitZeroWhenNonSecretIsCommittedButFileContainsSecretPreviously(t
 }
 
 // Need to work on this test case as talismanrc does  not yet support comments
-// func TestAddingSecretKeyShouldExitZeroIfPEMFilesAreIgnoredAndCommented(t *testing.T) {
-// 	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
-// 		git.SetupBaselineFiles("simple-file")
-// 		git.CreateFileWithContents("private.pem", "secret")
-// 		git.CreateFileWithContents(".talismanrc", talismanRCDataWithIgnoreDetector)
-// 		git.AddAndcommit("*", "add private key")
+func TestAddingSecretKeyShouldExitZeroIfPEMFilesAreIgnoredAndCommented(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		git.SetupBaselineFiles("simple-file")
+		git.CreateFileWithContents("private.pem", "secret")
+		git.CreateFileWithContents(".talismanrc", talismanRCDataWithIgnoreDetectorWithFilename)
+		git.AddAndcommit("*", "add private key")
 
-// 		assert.Equal(t, 0, runTalismanInPrePushMode(git), "Expected run() to return 0 and pass as pem file was ignored")
-// 	})
-// }
+		assert.Equal(t, 0, runTalismanInPrePushMode(git), "Expected run() to return 0 and pass as pem file was ignored")
+	})
+}
 
 func TestAddingSecretKeyShouldExitOneIfTheyContainBadContentButOnlyFilenameDetectorWasIgnored(t *testing.T) {
 	withNewTmpGitRepo(func(git *git_testing.GitTesting) {

--- a/cmd/checksum_cmd.go
+++ b/cmd/checksum_cmd.go
@@ -24,9 +24,8 @@ func NewChecksumCmd(fileNamePatterns []string) *ChecksumCmd {
 
 func (s *ChecksumCmd) Run() int {
 	repo := gitrepo.RepoLocatedAt(s.repoRoot)
-	err := s.hasher.Start()
-	if err != nil {
-		logrus.Errorf("unable to start hasher: %v", err)
+	if s.hasher == nil {
+		logrus.Errorf("unable to start hasher")
 		return EXIT_FAILURE
 	}
 
@@ -35,7 +34,6 @@ func (s *ChecksumCmd) Run() int {
 
 	cc := checksumcalculator.NewChecksumCalculator(s.hasher, gitTrackedFilesAsAdditions)
 	rcSuggestion := cc.SuggestTalismanRC(s.fileNamePatterns)
-	s.hasher.Shutdown()
 
 	if rcSuggestion != "" {
 		fmt.Print(rcSuggestion)

--- a/cmd/checksum_cmd.go
+++ b/cmd/checksum_cmd.go
@@ -21,11 +21,11 @@ func (s *ChecksumCmd) Run() int {
 	repo := gitrepo.RepoLocatedAt(wd)
 	gitTrackedFilesAsAdditions := repo.TrackedFilesAsAdditions()
 	gitTrackedFilesAsAdditions = append(gitTrackedFilesAsAdditions, repo.StagedAdditions()...)
-	cc := checksumcalculator.NewChecksumCalculator(utility.DefaultSHA256Hasher{}, gitTrackedFilesAsAdditions)
+	cc := checksumcalculator.NewChecksumCalculator(utility.MakeHasher("checksum", wd), gitTrackedFilesAsAdditions)
 	rcSuggestion := cc.SuggestTalismanRC(s.fileNamePatterns)
 	if rcSuggestion != "" {
 		fmt.Print(rcSuggestion)
-		return 0
+		return EXIT_SUCCESS
 	}
-	return 1
+	return EXIT_FAILURE
 }

--- a/cmd/checksum_cmd_test.go
+++ b/cmd/checksum_cmd_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"talisman/git_testing"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChecksumCalculatorShouldExitSuccess(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		git.SetupBaselineFiles("simple-file.txt")
+		git.CreateFileWithContents("private.pem", "secret")
+		git.CreateFileWithContents("another/private.pem", "secret")
+		git.CreateFileWithContents("sample.txt", "password")
+		os.Chdir(git.GetRoot())
+
+		checksumCmd := NewChecksumCmd([]string{"*.txt"})
+		assert.Equal(t, 0, checksumCmd.Run(), "Expected run() to return 0 as given patterns are found and .talsimanrc is suggested")
+		options.Checksum = ""
+	})
+}
+
+func TestChecksumCalculatorShouldExitFailure(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		git.SetupBaselineFiles("simple-file.txt")
+		git.CreateFileWithContents("private.pem", "secret")
+		git.CreateFileWithContents("another/private.pem", "secret")
+		git.CreateFileWithContents("sample.txt", "password")
+		os.Chdir(git.GetRoot())
+
+		checksumCmd := NewChecksumCmd([]string{"*.java"})
+		assert.Equal(t, 1, checksumCmd.Run(), "Expected run() to return 0 as given patterns are found and .talsimanrc is suggested")
+		options.Checksum = ""
+	})
+}

--- a/cmd/checksum_cmd_test.go
+++ b/cmd/checksum_cmd_test.go
@@ -1,14 +1,10 @@
 package main
 
 import (
-	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"talisman/git_testing"
-	mock "talisman/internal/mock/utility"
 	"testing"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestChecksumCalculatorShouldExitSuccess(t *testing.T) {
@@ -39,12 +35,9 @@ func TestChecksumCalculatorShouldExitFailure(t *testing.T) {
 	})
 }
 
-func TestChecksumCalculatorShouldExitFailureWhenHasherStarFails(t *testing.T) {
+func TestChecksumCalculatorShouldExitFailureWhenHasherIsEmpty(t *testing.T) {
 	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
-		ctrl := gomock.NewController(t)
-		hasher := mock.NewMockSHA256Hasher(ctrl)
-		checksumCmd := ChecksumCmd{[]string{"*.java"}, hasher, git.GetRoot()}
-		hasher.EXPECT().Start().Return(fmt.Errorf("fail this test because hasher failed to start"))
+		checksumCmd := ChecksumCmd{[]string{"*.java"}, nil, git.GetRoot()}
 		assert.Equal(t, 1, checksumCmd.Run(), "Expected run() to return 1 because hasher failed to start")
 	})
 }

--- a/cmd/pattern_cmd.go
+++ b/cmd/pattern_cmd.go
@@ -18,7 +18,8 @@ func NewPatternCmd(pattern string) *PatternCmd {
 
 	files, _ := doublestar.Glob(pattern)
 	for _, file := range files {
-		data, err := ReadFile(file)
+		log.Debugf("reading file %s", file)
+		data, err := utility.SafeReadFile(file)
 
 		if err != nil {
 			log.Warnf("Error reading file: %s. Skipping", file)
@@ -29,10 +30,5 @@ func NewPatternCmd(pattern string) *PatternCmd {
 		additions = append(additions, newAddition)
 	}
 
-	return &PatternCmd{NewRunner(additions, PrePush)}
-}
-
-func ReadFile(filepath string) ([]byte, error) {
-	log.Debugf("reading file %s", filepath)
-	return utility.SafeReadFile(filepath)
+	return &PatternCmd{NewRunner(additions, "pattern")}
 }

--- a/cmd/pattern_cmd.go
+++ b/cmd/pattern_cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bmatcuk/doublestar"
 )
 
-type PatternCmd struct{
+type PatternCmd struct {
 	*runner
 }
 
@@ -29,7 +29,7 @@ func NewPatternCmd(pattern string) *PatternCmd {
 		additions = append(additions, newAddition)
 	}
 
-	return &PatternCmd{NewRunner(additions)}
+	return &PatternCmd{NewRunner(additions, PrePush)}
 }
 
 func ReadFile(filepath string) ([]byte, error) {

--- a/cmd/pre_commit_hook.go
+++ b/cmd/pre_commit_hook.go
@@ -6,7 +6,7 @@ import (
 	"talisman/gitrepo"
 )
 
-type PreCommitHook struct{
+type PreCommitHook struct {
 	runner
 }
 
@@ -14,5 +14,5 @@ func NewPreCommitHook() *PreCommitHook {
 	wd, _ := os.Getwd()
 	repo := gitrepo.RepoLocatedAt(wd)
 
-	return &PreCommitHook{*NewRunner(repo.GetDiffForStagedFiles())}
+	return &PreCommitHook{*NewRunner(repo.GetDiffForStagedFiles(), PreCommit)}
 }

--- a/cmd/pre_push_hook.go
+++ b/cmd/pre_push_hook.go
@@ -29,7 +29,7 @@ func NewPrePushHook(stdin io.Reader) *PrePushHook {
 		localCommit,
 		remoteRef,
 		remoteCommit,
-		NewRunner(nil)}
+		NewRunner(nil, PrePush)}
 	prePushHook.additions = prePushHook.getRepoAdditions()
 	return prePushHook
 }

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -10,27 +10,19 @@ import (
 	"talisman/talismanrc"
 )
 
-const (
-	//CompletedSuccessfully is an exit status that says that the current runners run completed without errors
-	CompletedSuccessfully = 0
-
-	//CompletedWithErrors is an exit status that says that the current runners run completed with failures
-	CompletedWithErrors = 1
-)
-
 //runner represents a single run of the validations for a given commit range
 type runner struct {
 	additions []gitrepo.Addition
 	results   *helpers.DetectionResults
-	hooktype  string
+	mode      string
 }
 
 //NewRunner returns a new runner.
-func NewRunner(additions []gitrepo.Addition, hooktype string) *runner {
+func NewRunner(additions []gitrepo.Addition, mode string) *runner {
 	return &runner{
 		additions: additions,
 		results:   helpers.NewDetectionResults(talismanrc.HookMode),
-		hooktype:  hooktype,
+		mode:      mode,
 	}
 }
 
@@ -38,7 +30,7 @@ func NewRunner(additions []gitrepo.Addition, hooktype string) *runner {
 func (r *runner) Run(tRC *talismanrc.TalismanRC, promptContext prompt.PromptContext) int {
 	setCustomSeverities(tRC)
 	additionsToScan := tRC.FilterAdditions(r.additions)
-	detector.DefaultChain(tRC, r.hooktype).Test(additionsToScan, tRC, r.results)
+	detector.DefaultChain(tRC, r.mode).Test(additionsToScan, tRC, r.results)
 	r.printReport(promptContext)
 	exitStatus := r.exitStatus()
 	return exitStatus
@@ -61,7 +53,7 @@ func (r *runner) printReport(promptContext prompt.PromptContext) {
 
 func (r *runner) exitStatus() int {
 	if r.results.HasFailures() {
-		return CompletedWithErrors
+		return EXIT_FAILURE
 	}
-	return CompletedSuccessfully
+	return EXIT_SUCCESS
 }

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -22,13 +22,15 @@ const (
 type runner struct {
 	additions []gitrepo.Addition
 	results   *helpers.DetectionResults
+	hooktype  string
 }
 
 //NewRunner returns a new runner.
-func NewRunner(additions []gitrepo.Addition) *runner {
+func NewRunner(additions []gitrepo.Addition, hooktype string) *runner {
 	return &runner{
 		additions: additions,
 		results:   helpers.NewDetectionResults(talismanrc.HookMode),
+		hooktype:  hooktype,
 	}
 }
 
@@ -36,7 +38,7 @@ func NewRunner(additions []gitrepo.Addition) *runner {
 func (r *runner) Run(tRC *talismanrc.TalismanRC, promptContext prompt.PromptContext) int {
 	setCustomSeverities(tRC)
 	additionsToScan := tRC.FilterAdditions(r.additions)
-	detector.DefaultChain(tRC).Test(additionsToScan, tRC, r.results)
+	detector.DefaultChain(tRC, r.hooktype).Test(additionsToScan, tRC, r.results)
 	r.printReport(promptContext)
 	exitStatus := r.exitStatus()
 	return exitStatus

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -47,7 +47,7 @@ func (r *runner) printReport(promptContext prompt.PromptContext) {
 		fmt.Println(r.results.ReportWarnings())
 	}
 	if r.results.HasIgnores() || r.results.HasFailures() {
-		r.results.Report(promptContext)
+		r.results.Report(promptContext, r.mode)
 	}
 }
 

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -27,7 +27,7 @@ type ScannerCmd struct {
 //Run scans git commit history for potential secrets and returns 0 or 1 as exit code
 func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 	fmt.Printf("\n\n")
-	utility.CreateArt("Running ScanMode..")
+	utility.CreateArt("Running Scan..")
 	detector.DefaultChain(tRC, "default").Test(s.additions, tRC, s.results)
 	reportsPath, err := report.GenerateReport(s.results, s.reportDirectory)
 	if err != nil {

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -13,6 +13,10 @@ import (
 	logr "github.com/sirupsen/logrus"
 )
 
+const (
+	SCAN_MODE = "scan"
+)
+
 type ScannerCmd struct {
 	additions       []gitrepo.Addition
 	results         *helpers.DetectionResults
@@ -23,11 +27,11 @@ type ScannerCmd struct {
 func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 	fmt.Printf("\n\n")
 	utility.CreateArt("Running ScanMode..")
-	detector.DefaultChain(tRC, PrePush).Test(s.additions, tRC, s.results)
+	detector.DefaultChain(tRC, SCAN_MODE).Test(s.additions, tRC, s.results)
 	reportsPath, err := report.GenerateReport(s.results, s.reportDirectory)
 	if err != nil {
 		logr.Errorf("error while generating report: %v", err)
-		return CompletedWithErrors
+		return EXIT_FAILURE
 	}
 
 	fmt.Printf("\nPlease check '%s' folder for the talisman scan report\n\n", reportsPath)
@@ -36,9 +40,9 @@ func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 
 func (s *ScannerCmd) exitStatus() int {
 	if s.results.HasFailures() {
-		return CompletedWithErrors
+		return EXIT_FAILURE
 	}
-	return CompletedSuccessfully
+	return EXIT_SUCCESS
 }
 
 //NewScannerCmd Returns a new scanner command

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -23,7 +23,7 @@ type ScannerCmd struct {
 func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 	fmt.Printf("\n\n")
 	utility.CreateArt("Running ScanMode..")
-	detector.DefaultChain(tRC).Test(s.additions, tRC, s.results)
+	detector.DefaultChain(tRC, PrePush).Test(s.additions, tRC, s.results)
 	reportsPath, err := report.GenerateReport(s.results, s.reportDirectory)
 	if err != nil {
 		logr.Errorf("error while generating report: %v", err)

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"talisman/detector"
 	"talisman/detector/helpers"
 	"talisman/gitrepo"
@@ -27,7 +28,7 @@ type ScannerCmd struct {
 func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 	fmt.Printf("\n\n")
 	utility.CreateArt("Running ScanMode..")
-	detector.DefaultChain(tRC, SCAN_MODE).Test(s.additions, tRC, s.results)
+	detector.DefaultChain(tRC, "default").Test(s.additions, tRC, s.results)
 	reportsPath, err := report.GenerateReport(s.results, s.reportDirectory)
 	if err != nil {
 		logr.Errorf("error while generating report: %v", err)
@@ -47,7 +48,9 @@ func (s *ScannerCmd) exitStatus() int {
 
 //NewScannerCmd Returns a new scanner command
 func NewScannerCmd(ignoreHistory bool, reportDirectory string) *ScannerCmd {
-	additions := scanner.GetAdditions(ignoreHistory)
+	repoRoot, _ := os.Getwd()
+	reader := gitrepo.NewBatchGitObjectHashReader(repoRoot)
+	additions := scanner.GetAdditions(ignoreHistory, reader)
 	return &ScannerCmd{
 		additions:       additions,
 		results:         helpers.NewDetectionResults(talismanrc.ScanMode),

--- a/cmd/scanner_cmd_test.go
+++ b/cmd/scanner_cmd_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"talisman/git_testing"
+	"talisman/talismanrc"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScannerCmdRunsSuccessfully(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		git.SetupBaselineFiles("simple-file")
+		git.CreateFileWithContents("some-dir/should-be-included.txt", "safeContents")
+		git.AddAndcommit("*", "Start of Scan")
+		os.Chdir(git.GetRoot())
+
+		scannerCmd := NewScannerCmd(true, git.GetRoot())
+		scannerCmd.Run(&talismanrc.TalismanRC{})
+		assert.Equal(t, 0, scannerCmd.exitStatus(), "Expected ScannerCmd.exitStatus() to return 0 since no secret is found")
+	})
+}
+
+func TestScannerCmdDetectsSecretAndFails(t *testing.T) {
+	withNewTmpGitRepo(func(git *git_testing.GitTesting) {
+		git.SetupBaselineFiles("simple-file")
+		git.CreateFileWithContents("some-dir/file-with-secret.txt", awsAccessKeyIDExample)
+		git.AddAndcommit("*", "Initial Commit")
+		git.RemoveFile("some-dir/file-with-secret.txt")
+		git.AddAndcommit("*", "Removed secret")
+		git.CreateFileWithContents("some-dir/safe-file.txt", "safeContents")
+		git.AddAndcommit("*", "Start of Scan")
+		os.Chdir(git.GetRoot())
+
+		scannerCmd := NewScannerCmd(false, git.GetRoot())
+		scannerCmd.Run(&talismanrc.TalismanRC{})
+		assert.Equal(t, 1, scannerCmd.exitStatus(), "Expected ScannerCmd.exitStatus() to return 1 since secret present in history")
+	})
+}

--- a/cmd/talisman.go
+++ b/cmd/talisman.go
@@ -143,7 +143,7 @@ func run(promptContext prompt.PromptContext) (returnCode int) {
 	fields := make(map[string]interface{})
 	_ = json.Unmarshal(optionsBytes, &fields)
 	log.WithFields(fields).Debug("Talisman execution environment")
-	defer  utility.DestroyHasher()
+	defer  utility.DestroyHashers()
 	if options.Checksum != "" {
 		log.Infof("Running %s patterns against checksum calculator", options.Checksum)
 		return NewChecksumCmd(strings.Fields(options.Checksum)).Run()

--- a/cmd/talisman.go
+++ b/cmd/talisman.go
@@ -223,6 +223,7 @@ func setupProfiling() func() {
 			<-memProfTimer.C
 			_ = pprof.WriteHeapProfile(memProfFile)
 		}
+		_ = memProfFile.Close()
 	}()
 
 	return func() {
@@ -230,6 +231,5 @@ func setupProfiling() func() {
 		pprof.StopCPUProfile()
 		log.Info("Profiling completed")
 		_ = cpuProfFile.Close()
-		_ = memProfFile.Close()
 	}
 }

--- a/cmd/talisman.go
+++ b/cmd/talisman.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime/pprof"
 	"strings"
+	"talisman/utility"
 	"time"
 
 	"talisman/prompt"
@@ -142,7 +143,7 @@ func run(promptContext prompt.PromptContext) (returnCode int) {
 	fields := make(map[string]interface{})
 	_ = json.Unmarshal(optionsBytes, &fields)
 	log.WithFields(fields).Debug("Talisman execution environment")
-
+	defer  utility.DestroyHasher()
 	if options.Checksum != "" {
 		log.Infof("Running %s patterns against checksum calculator", options.Checksum)
 		return NewChecksumCmd(strings.Fields(options.Checksum)).Run()

--- a/cmd/talisman_test.go
+++ b/cmd/talisman_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_setLogLevel(t *testing.T) {
+	levels := []string{"error", "warn", "info", "debug", "unknown"}
+	expectedLogrusLevels := []logrus.Level{
+		logrus.ErrorLevel, logrus.WarnLevel,
+		logrus.InfoLevel, logrus.DebugLevel, logrus.ErrorLevel}
+
+	for idx, level := range levels {
+		options.LogLevel = level
+		setLogLevel()
+		assert.True(
+			t,
+			logrus.IsLevelEnabled(expectedLogrusLevels[idx]),
+			fmt.Sprintf("expected level to be %v for options.LogLevel = %s", expectedLogrusLevels[idx], level))
+
+		options.Debug = true
+		setLogLevel()
+		assert.True(
+			t,
+			logrus.IsLevelEnabled(logrus.DebugLevel),
+			"expected level to be debug when options.Debug is set")
+	}
+}

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -57,7 +57,7 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 	log.Printf("Number of files to scan: %d\n", len(currentAdditions))
 	log.Printf("Number of detectors: %d\n", len(dc.detectors))
 	total := len(currentAdditions) * len(dc.detectors)
-	progressBar := utility.GetProgressBar()
+	progressBar := utility.GetProgressBar(os.Stdout)
 	progressBar.Start(total)
 	for _, v := range dc.detectors {
 		v.Test(cc, currentAdditions, talismanRC, result, func() {

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -1,8 +1,6 @@
 package detector
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/cheggaaa/pb/v3"
 	"os"
 	"talisman/checksumcalculator"
 	"talisman/detector/detector"
@@ -13,6 +11,9 @@ import (
 	"talisman/gitrepo"
 	"talisman/talismanrc"
 	"talisman/utility"
+
+	"github.com/cheggaaa/pb/v3"
+	log "github.com/sirupsen/logrus"
 )
 
 //Chain represents a chain of Detectors.
@@ -49,7 +50,7 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 	wd, _ := os.Getwd()
 	repo := gitrepo.RepoLocatedAt(wd)
 	allAdditions := repo.TrackedFilesAsAdditions()
-	hasher := utility.DefaultSHA256Hasher{}
+	hasher := utility.NewGitHeadSHA256Hasher(wd)
 	calculator := checksumcalculator.NewChecksumCalculator(hasher, append(allAdditions, currentAdditions...))
 	cc := helpers.NewChecksumCompare(calculator, hasher, talismanRC)
 	log.Printf("Number of files to scan: %d\n", len(currentAdditions))

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -51,7 +51,6 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 	repo := gitrepo.RepoLocatedAt(wd)
 	allAdditions := repo.TrackedFilesAsAdditions()
 	hasher := utility.MakeHasher(dc.mode, wd)
-	hasher.Start()
 	calculator := checksumcalculator.NewChecksumCalculator(hasher, append(allAdditions, currentAdditions...))
 	cc := helpers.NewChecksumCompare(calculator, hasher, talismanRC)
 	log.Printf("Number of files to scan: %d\n", len(currentAdditions))
@@ -65,5 +64,4 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 		})
 	}
 	progressBar.Finish()
-	hasher.Shutdown()
 }

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -57,7 +57,7 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 	log.Printf("Number of files to scan: %d\n", len(currentAdditions))
 	log.Printf("Number of detectors: %d\n", len(dc.detectors))
 	total := len(currentAdditions) * len(dc.detectors)
-	progressBar := utility.GetProgressBar(os.Stdout)
+	progressBar := utility.GetProgressBar(os.Stdout, "Talisman Scan")
 	progressBar.Start(total)
 	for _, v := range dc.detectors {
 		v.Test(cc, currentAdditions, talismanRC, result, func() {

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -12,7 +12,6 @@ import (
 	"talisman/talismanrc"
 	"talisman/utility"
 
-	"github.com/cheggaaa/pb/v3"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -20,23 +19,23 @@ import (
 //It is itself a detector.
 type Chain struct {
 	detectors []detector.Detector
-	hooktype  string
+	mode      string
 }
 
 //NewChain returns an empty DetectorChain
 //It is itself a detector, but it tests nothing.
 func NewChain(hooktype string) *Chain {
-	result := Chain{make([]detector.Detector, 0), hooktype}
+	result := Chain{[]detector.Detector{}, hooktype}
 	return &result
 }
 
 //DefaultChain returns a DetectorChain with pre-configured detectors
-func DefaultChain(tRC *talismanrc.TalismanRC, hooktype string) *Chain {
-	result := NewChain(hooktype)
-	result.AddDetector(filename.DefaultFileNameDetector(tRC.Threshold))
-	result.AddDetector(filecontent.NewFileContentDetector(tRC))
-	result.AddDetector(pattern.NewPatternDetector(tRC.CustomPatterns))
-	return result
+func DefaultChain(tRC *talismanrc.TalismanRC, runMode string) *Chain {
+	chain := NewChain(runMode)
+	chain.AddDetector(filename.DefaultFileNameDetector(tRC.Threshold))
+	chain.AddDetector(filecontent.NewFileContentDetector(tRC))
+	chain.AddDetector(pattern.NewPatternDetector(tRC.CustomPatterns))
+	return chain
 }
 
 //AddDetector adds the detector that is passed in to the chain
@@ -51,18 +50,13 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 	wd, _ := os.Getwd()
 	repo := gitrepo.RepoLocatedAt(wd)
 	allAdditions := repo.TrackedFilesAsAdditions()
-	var hasher utility.SHA256Hasher
-	if dc.hooktype == "pre-push" {
-		hasher = utility.NewGitHeadFileSHA256Hasher(wd)
-	} else {
-		hasher = utility.NewGitFileSHA256Hasher(wd)
-	}
+	hasher := utility.MakeHasher(dc.mode, wd)
 	calculator := checksumcalculator.NewChecksumCalculator(hasher, append(allAdditions, currentAdditions...))
 	cc := helpers.NewChecksumCompare(calculator, hasher, talismanRC)
 	log.Printf("Number of files to scan: %d\n", len(currentAdditions))
 	log.Printf("Number of detectors: %d\n", len(dc.detectors))
 	total := len(currentAdditions) * len(dc.detectors)
-	var progressBar = getProgressBar()
+	progressBar := utility.GetProgressBar()
 	progressBar.Start(total)
 	for _, v := range dc.detectors {
 		v.Test(cc, currentAdditions, talismanRC, result, func() {
@@ -70,50 +64,4 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 		})
 	}
 	progressBar.Finish()
-}
-
-func getProgressBar() progressBar {
-	if isTerminal() {
-		return &defaultProgressBar{}
-	} else {
-		return &noOpProgressBar{}
-	}
-}
-
-func isTerminal() bool {
-	fileInfo, _ := os.Stdout.Stat()
-	return (fileInfo.Mode() & os.ModeCharDevice) != 0
-}
-
-type progressBar interface {
-	Start(int)
-	Increment()
-	Finish()
-}
-
-type noOpProgressBar struct {
-}
-
-func (d *noOpProgressBar) Start(int) {}
-
-func (d *noOpProgressBar) Increment() {}
-
-func (d *noOpProgressBar) Finish() {}
-
-type defaultProgressBar struct {
-	bar *pb.ProgressBar
-}
-
-func (d *defaultProgressBar) Start(total int) {
-	bar := pb.ProgressBarTemplate(`{{ red "Talisman Scan:" }} {{counters .}} {{ bar . "<" "-" (cycle . "↖" "↗" "↘" "↙" ) "." ">"}} {{percent . | rndcolor }} {{green}} {{blue}}`).New(total)
-	bar.Set(pb.Terminal, true)
-	d.bar = bar.Start()
-}
-
-func (d *defaultProgressBar) Increment() {
-	d.bar.Increment()
-}
-
-func (d *defaultProgressBar) Finish() {
-	d.bar.Finish()
 }

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -51,6 +51,7 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 	repo := gitrepo.RepoLocatedAt(wd)
 	allAdditions := repo.TrackedFilesAsAdditions()
 	hasher := utility.MakeHasher(dc.mode, wd)
+	hasher.Start()
 	calculator := checksumcalculator.NewChecksumCalculator(hasher, append(allAdditions, currentAdditions...))
 	cc := helpers.NewChecksumCompare(calculator, hasher, talismanRC)
 	log.Printf("Number of files to scan: %d\n", len(currentAdditions))
@@ -64,4 +65,5 @@ func (dc *Chain) Test(currentAdditions []gitrepo.Addition, talismanRC *talismanr
 		})
 	}
 	progressBar.Finish()
+	hasher.Shutdown()
 }

--- a/detector/chain_test.go
+++ b/detector/chain_test.go
@@ -28,14 +28,14 @@ func (p PassingDetection) Test(comparator helpers.ChecksumCompare, currentAdditi
 }
 
 func TestEmptyValidationChainPassesAllValidations(t *testing.T) {
-	v := NewChain()
+	v := NewChain("pre-push")
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	v.Test(nil, &talismanrc.TalismanRC{}, results)
 	assert.False(t, results.HasFailures(), "Empty validation chain is expected to always pass")
 }
 
 func TestValidationChainWithFailingValidationAlwaysFails(t *testing.T) {
-	v := NewChain()
+	v := NewChain("pre-push")
 	v.AddDetector(PassingDetection{})
 	v.AddDetector(FailingDetection{})
 	results := helpers.NewDetectionResults(talismanrc.HookMode)

--- a/detector/filecontent/base64_aggressive_detector_test.go
+++ b/detector/filecontent/base64_aggressive_detector_test.go
@@ -23,7 +23,7 @@ func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 
 	aggressiveModeFileContentDetector.
 		Test(
-			helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, _blankTalismanRC),
+			helpers.NewChecksumCompare(nil, utility.MakeHasher("default", "."), _blankTalismanRC),
 			additions,
 			_blankTalismanRC,
 			results,
@@ -40,7 +40,7 @@ func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t 
 
 	aggressiveModeFileContentDetector.
 		Test(
-			helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, _blankTalismanRC),
+			helpers.NewChecksumCompare(nil, utility.MakeHasher("default", "."), _blankTalismanRC),
 			additions,
 			_blankTalismanRC,
 			results,
@@ -62,7 +62,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *
 
 	aggressiveModeFileContentDetector.
 		Test(
-			helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, _blankTalismanRC),
+			helpers.NewChecksumCompare(nil, utility.MakeHasher("default", "."), _blankTalismanRC),
 			additions,
 			_blankTalismanRC,
 			results,

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -2,7 +2,6 @@ package filecontent
 
 import (
 	"fmt"
-	"github.com/golang/mock/gomock"
 	"strings"
 	"talisman/detector/helpers"
 	"talisman/detector/severity"
@@ -12,12 +11,14 @@ import (
 	"talisman/utility"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+
 	"github.com/stretchr/testify/assert"
 )
 
 var emptyTalismanRC = &talismanrc.TalismanRC{IgnoreConfigs: []talismanrc.IgnoreConfig{}}
 var defaultChecksumCompareUtility = helpers.
-	NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, emptyTalismanRC)
+	NewChecksumCompare(nil, utility.MakeHasher("default", "."), emptyTalismanRC)
 var dummyCallback = func() {}
 
 func TestShouldNotFlagSafeText(t *testing.T) {
@@ -44,7 +45,7 @@ func TestShouldIgnoreFileIfNeeded(t *testing.T) {
 		CalculateCollectiveChecksumForPattern("filename").
 		Return("mock-checksum-for-filename")
 	checksumCompare := helpers.
-		NewChecksumCompare(mockChecksumCalculator, utility.DefaultSHA256Hasher{}, talismanRCIWithFilenameIgnore)
+		NewChecksumCompare(mockChecksumCalculator, utility.MakeHasher("default", "."), talismanRCIWithFilenameIgnore)
 
 	NewFileContentDetector(talismanRCIWithFilenameIgnore).
 		Test(checksumCompare, additions, talismanRCIWithFilenameIgnore, results, dummyCallback)
@@ -201,7 +202,7 @@ func TestShouldNotFlagPotentialCreditCardNumberIfAboveThreshold(t *testing.T) {
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(creditCardNumber))}
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	checksumCompareWithThreshold := helpers.
-		NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanRCWithThreshold)
+		NewChecksumCompare(nil, utility.MakeHasher("default", "."), talismanRCWithThreshold)
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(checksumCompareWithThreshold, additions, talismanRCWithThreshold, results, dummyCallback)

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultChecksumCompareUtility = helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanRC)
+var defaultChecksumCompareUtility = helpers.NewChecksumCompare(nil, utility.MakeHasher("default", "."), talismanRC)
 
 func TestShouldFlagPotentialSSHPrivateKeys(t *testing.T) {
 	shouldFail("id_rsa", "^.+_rsa$", severity.Low, t)

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
+var defaultHasher = utility.MakeHasher("default", ".")
 
 func TestShouldFlagLargeFiles(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("more than one byte")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, &talismanrc.TalismanRC{}), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, defaultHasher, talismanRC), additions, talismanRC, results, func() {})
 	assert.True(t, results.HasFailures(), "Expected file to fail the check against file size detector.")
 }
 
@@ -27,7 +28,7 @@ func TestShouldNotFlagLargeFilesIfThresholdIsBelowSeverity(t *testing.T) {
 	content := []byte("more than one byte")
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanRCWithThreshold), additions, talismanRCWithThreshold, results, func() {})
+	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, defaultHasher, talismanRCWithThreshold), additions, talismanRCWithThreshold, results, func() {})
 	assert.False(t, results.HasFailures(), "Expected file to not to fail the check against file size detector.")
 	assert.True(t, results.HasWarnings(), "Expected file to have warnings against file size detector.")
 }
@@ -36,7 +37,7 @@ func TestShouldNotFlagSmallFiles(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("m")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, &talismanrc.TalismanRC{}), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, defaultHasher, talismanRC), additions, talismanRC, results, func() {})
 	assert.False(t, results.HasFailures(), "Expected file to not to fail the check against file size detector.")
 }
 
@@ -54,6 +55,6 @@ func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {
 	talismanRC.IgnoreConfigs[0] = fileIgnoreConfig
 
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanRC), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, defaultHasher, talismanRC), additions, talismanRC, results, func() {})
 	assert.True(t, results.Successful(), "expected file %s to be ignored by file size detector", filename)
 }

--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -233,7 +233,7 @@ func (r *DetectionResults) ReportWarnings() string {
 }
 
 //Report returns a string documenting the various failures and ignored files for the current run
-func (r *DetectionResults) Report(promptContext prompt.PromptContext) string {
+func (r *DetectionResults) Report(promptContext prompt.PromptContext, mode string) string {
 	var result string
 	var filePathsForFailures []string
 	var data [][]string
@@ -257,14 +257,14 @@ func (r *DetectionResults) Report(promptContext prompt.PromptContext) string {
 		table.AppendBulk(data)
 		table.Render()
 		fmt.Println()
-		r.suggestTalismanRC(filePathsForFailures, promptContext)
+		r.suggestTalismanRC(filePathsForFailures, promptContext, mode)
 	}
 	return result
 }
 
-func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext prompt.PromptContext) {
+func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext prompt.PromptContext, mode string) {
 	var entriesToAdd []talismanrc.IgnoreConfig
-	hasher := utility.DefaultSHA256Hasher{}
+	hasher := utility.MakeHasher(mode, ".")
 	for _, filePath := range filePaths {
 		currentChecksum := hasher.CollectiveSHA256Hash([]string{filePath})
 		fileIgnoreConfig := talismanrc.BuildIgnoreConfig(r.mode, filePath, currentChecksum, []string{})

--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -55,44 +55,6 @@ type DetectionResults struct {
 	Results []ResultsDetails `json:"results"`
 }
 
-func (r *ResultsDetails) getWarningDataByCategoryAndMessage(failureMessage string, category string) *Details {
-	detail := getDetailsByCategoryAndMessage(r.WarningList, category, failureMessage)
-	r.WarningList = append(r.WarningList, *detail)
-	return detail
-}
-
-func (r *ResultsDetails) getFailureDataByCategoryAndMessage(failureMessage string, category string) *Details {
-	detail := getDetailsByCategoryAndMessage(r.FailureList, category, failureMessage)
-	if detail == nil {
-		detail = &Details{category, failureMessage, make([]string, 0), severity.Low}
-		r.FailureList = append(r.FailureList, *detail)
-	}
-	return detail
-}
-
-func (r *ResultsDetails) addIgnoreDataByCategory(category string) {
-	isCategoryAlreadyPresent := false
-	for _, detail := range r.IgnoreList {
-		if strings.Compare(detail.Category, category) == 0 {
-			isCategoryAlreadyPresent = true
-		}
-	}
-	if !isCategoryAlreadyPresent {
-		detail := Details{category, "", make([]string, 0), severity.Low}
-		r.IgnoreList = append(r.IgnoreList, detail)
-	}
-}
-
-func getDetailsByCategoryAndMessage(detailsList []Details, category string, failureMessage string) *Details {
-	for _, detail := range detailsList {
-		if strings.Compare(detail.Category, category) == 0 && strings.Compare(detail.Message, failureMessage) == 0 {
-			return &detail
-		}
-	}
-
-	return nil
-}
-
 func (r *DetectionResults) getResultDetailsForFilePath(fileName gitrepo.FilePath) *ResultsDetails {
 	for _, resultDetail := range r.Results {
 		if resultDetail.Filename == fileName {

--- a/detector/helpers/detection_results_test.go
+++ b/detector/helpers/detection_results_test.go
@@ -88,7 +88,7 @@ func TestErrorExitCodeInInteractive(t *testing.T) {
 	prompter.EXPECT().Confirm(gomock.Any()).Return(false).Times(2)
 	results.Fail("some_file.pem", "filecontent", "Bomb", []string{}, severity.Low)
 	results.Fail("another.pem", "filecontent", "password", []string{}, severity.Low)
-	results.Report(promptContext)
+	results.Report(promptContext, "default")
 	assert.True(t, results.HasFailures())
 }
 
@@ -103,7 +103,7 @@ func TestSuccessExitCodeInInteractive(t *testing.T) {
 	prompter.EXPECT().Confirm(gomock.Any()).Return(true).Times(2)
 	results.Fail("some_file.pem", "filecontent", "Bomb", []string{}, severity.Low)
 	results.Fail("another.pem", "filecontent", "password", []string{}, severity.Low)
-	results.Report(promptContext)
+	results.Report(promptContext, "default")
 	assert.False(t, results.HasFailures())
 }
 
@@ -152,7 +152,7 @@ func TestTalismanRCSuggestionWhenThereAreFailures(t *testing.T) {
 		promptContext := prompt.NewPromptContext(true, prompter)
 		prompter.EXPECT().Confirm(gomock.Any()).Return(false).Times(0)
 
-		results.Report(promptContext)
+		results.Report(promptContext, "default")
 		bytesFromFile, err := afero.ReadFile(fs, ignoreFile)
 
 		assert.NoError(t, err)
@@ -165,7 +165,7 @@ func TestTalismanRCSuggestionWhenThereAreFailures(t *testing.T) {
 		prompter.EXPECT().Confirm("Do you want to add some_file.pem with above checksum in talismanrc ?").Return(false)
 		results.Fail("some_file.pem", "filecontent", "Bomb", []string{}, severity.Low)
 
-		results.Report(promptContext)
+		results.Report(promptContext, "default")
 		bytesFromFile, err := afero.ReadFile(fs, ignoreFile)
 
 		assert.NoError(t, err)
@@ -178,7 +178,7 @@ func TestTalismanRCSuggestionWhenThereAreFailures(t *testing.T) {
 		prompter.EXPECT().Confirm(gomock.Any()).Return(false).Times(0)
 		results.Fail("some_file.pem", "filecontent", "Bomb", []string{}, severity.Low)
 
-		results.Report(promptContext)
+		results.Report(promptContext, "default")
 		bytesFromFile, err := afero.ReadFile(fs, ignoreFile)
 
 		assert.NoError(t, err)
@@ -197,7 +197,7 @@ func TestTalismanRCSuggestionWhenThereAreFailures(t *testing.T) {
   checksum: 87139cc4d975333b25b6275f97680604add51b84eb8f4a3b9dcbbc652e6f27ac
 version: "1.0"
 `
-		results.Report(promptContext)
+		results.Report(promptContext, "default")
 		bytesFromFile, err := afero.ReadFile(fs, ignoreFile)
 
 		assert.NoError(t, err)
@@ -216,7 +216,7 @@ version: "1.0"
   checksum: 5bc0b0692a316bb2919263addaef0ffba3a21b9e1cca62a1028390e97e861e4e
 version: "1.0"
 `
-		results.Report(promptContext)
+		results.Report(promptContext, "default")
 		bytesFromFile, err := afero.ReadFile(fs, ignoreFile)
 
 		assert.NoError(t, err)
@@ -239,7 +239,7 @@ version: "1.0"
   checksum: 87139cc4d975333b25b6275f97680604add51b84eb8f4a3b9dcbbc652e6f27ac
 version: "1.0"
 `
-		results.Report(promptContext)
+		results.Report(promptContext, "default")
 		bytesFromFile, err := afero.ReadFile(fs, ignoreFile)
 
 		assert.NoError(t, err)

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultChecksumCompare = helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanRC)
+var defaultChecksumCompare = helpers.NewChecksumCompare(nil, utility.MakeHasher("default", "."), talismanRC)
 var dummyCallback = func() {}
 
 var (
@@ -101,7 +101,7 @@ func TestShouldOnlyWarnSecretPatternIfBelowThreshold(t *testing.T) {
 	filename := "secret.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
-	checksumCompare := helpers.NewChecksumCompare(nil, utility.DefaultSHA256Hasher{}, talismanRCWithThreshold)
+	checksumCompare := helpers.NewChecksumCompare(nil, utility.MakeHasher("default", "."), talismanRCWithThreshold)
 
 	NewPatternDetector(customPatterns).Test(checksumCompare, additions, talismanRCWithThreshold, results, dummyCallback)
 

--- a/gitrepo/constants.go
+++ b/gitrepo/constants.go
@@ -1,0 +1,9 @@
+package gitrepo
+
+const (
+	//GIT_STAGED_PREFIX is used to read a staged git file
+	GIT_STAGED_PREFIX = ""
+
+	//GIT_STAGED_PREFIX is used to read a commited git file
+	GIT_HEAD_PREFIX = "HEAD"
+)

--- a/gitrepo/git_readers.go
+++ b/gitrepo/git_readers.go
@@ -1,0 +1,120 @@
+package gitrepo
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Reader func(string) ([]byte, error)
+
+func NewCommittedRepoFileReader(wd string) Reader {
+	return makeReader(wd, GIT_HEAD_PREFIX)
+}
+
+func NewBatchGitObjectReader(root string) Reader {
+	repo := &GitRepo{root}
+	cmd := repo.makeRepoCommand("git", "cat-file", "--batch=%(objectsize)")
+	inputPipe, err := cmd.StdinPipe()
+	if err != nil {
+		logrus.Fatalf("error creating stdin pipe for batch git file reader subprocess: %v", err)
+	}
+	outputPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		logrus.Fatalf("error creating stdout pipe for batch git file reader subprocess: %v", err)
+	}
+	batchReader := BatchGitObjectReader{
+		repo:         repo,
+		cmd:          cmd,
+		inputWriter:  bufio.NewWriter(inputPipe),
+		outputReader: bufio.NewReader(outputPipe),
+	}
+	err = batchReader.start()
+	if err != nil {
+		logrus.Fatalf("error starting batch command: %v", err)
+	}
+	return batchReader.makeReader()
+}
+
+func NewRepoFileReader(wd string) Reader {
+	return makeReader(wd, GIT_STAGED_PREFIX)
+}
+
+func makeReader(repoRoot, prefix string) Reader {
+	return func(path string) ([]byte, error) {
+		return GitRepo{repoRoot}.readRepoFile(path, prefix)
+	}
+}
+
+type BatchGitObjectReader struct {
+	repo         *GitRepo
+	cmd          *exec.Cmd
+	inputWriter  *bufio.Writer
+	outputReader *bufio.Reader
+}
+
+func (bgor *BatchGitObjectReader) start() error {
+	return bgor.cmd.Start()
+}
+
+type gitCatFileReadResult struct {
+	contents []byte
+	err      error
+}
+
+func (bgor *BatchGitObjectReader) makeReader() Reader {
+	pathChan := make(chan (string))
+	resultsChan := make(chan (gitCatFileReadResult))
+	go bgor.doCatFile(pathChan, resultsChan)
+	return func(path string) ([]byte, error) {
+		pathChan <- path
+		result := <-resultsChan
+		return result.contents, result.err
+	}
+}
+
+func (bgor *BatchGitObjectReader) doCatFile(pathChan chan (string), resultsChan chan (gitCatFileReadResult)) {
+	for {
+		path := <-pathChan
+		//Write file-path expression to process input
+		bgor.inputWriter.Write([]byte(":" + path + "\n"))
+		bgor.inputWriter.Flush()
+
+		//Read line containing filesize from process output
+		filesizeBytes, err := bgor.outputReader.ReadBytes('\n')
+		if err != nil {
+			logrus.Errorf("error reading filesize: %v", err)
+			resultsChan <- gitCatFileReadResult{[]byte{}, err}
+			continue
+		}
+		filesize, err := strconv.Atoi(string(filesizeBytes[:len(filesizeBytes)-1]))
+		if err != nil {
+			logrus.Errorf("error parsing filesize: %v", err)
+			resultsChan <- gitCatFileReadResult{[]byte{}, err}
+			continue
+		}
+		logrus.Debugf("Git Batch Reader: FilePath: %v, Size:%v", path, filesize)
+
+		//Read file contents upto filesize bytes from process output
+		fileBytes := make([]byte, filesize)
+		n, err := io.ReadFull(bgor.outputReader, fileBytes)
+		if n != filesize || err != nil {
+			logrus.Errorf("error reading exactly %v bytes of %v: %v (read %v bytes)", filesize, path, err, n)
+			resultsChan <- gitCatFileReadResult{[]byte{}, err}
+			continue
+		}
+
+		//Read and discard trailing newline (not doing this will cause errors going forward)
+		b, err := bgor.outputReader.ReadByte()
+		if err != nil || b != '\n' {
+			resultsChan <- gitCatFileReadResult{[]byte{}, fmt.Errorf("error discarding trailing newline : %v trailing byte: %v", err, b)}
+			continue
+		}
+
+		resultsChan <- gitCatFileReadResult{fileBytes, nil}
+	}
+}

--- a/gitrepo/gitrepo.go
+++ b/gitrepo/gitrepo.go
@@ -183,8 +183,19 @@ func (repo GitRepo) ReadRepoFile(fileName string) ([]byte, error) {
 	return repo.rawExecuteRepoCommand("git", "cat-file", "-p", fmt.Sprintf(":%s", fileName))
 }
 
+//ReadCommitedRepoFile returns the contents of the supplied relative filename by locating it in the git repo
+func (repo GitRepo) ReadCommittedRepoFile(fileName string) ([]byte, error) {
+	path := filepath.Join(repo.root, fileName)
+	log.Debugf("reading file %s", path)
+	return repo.rawExecuteRepoCommand("git", "cat-file", "-p", fmt.Sprintf("HEAD:%s", fileName))
+}
+
 func NewRepoFileReader(wd string) func(string) ([]byte, error) {
 	return GitRepo{wd}.ReadRepoFile
+}
+
+func NewCommittedRepoFileReader(wd string) func(string) ([]byte, error) {
+	return GitRepo{wd}.ReadCommittedRepoFile
 }
 
 //ReadRepoFileOrNothing returns the contents of the supplied relative filename by locating it in the git repo.
@@ -194,7 +205,7 @@ func (repo GitRepo) ReadRepoFileOrNothing(fileName string) ([]byte, error) {
 	if _, err := os.Stat(filepath); err == nil {
 		return repo.ReadRepoFile(fileName)
 	}
-	return make([]byte, 0), nil
+	return []byte{}, nil
 }
 
 //CheckIfFileExists checks if the file exists on the file system. Does not look into the file contents

--- a/internal/mock/checksumcalculator/checksumcalculator.go
+++ b/internal/mock/checksumcalculator/checksumcalculator.go
@@ -5,48 +5,35 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockChecksumCalculator is a mock of ChecksumCalculator interface
+// MockChecksumCalculator is a mock of ChecksumCalculator interface.
 type MockChecksumCalculator struct {
 	ctrl     *gomock.Controller
 	recorder *MockChecksumCalculatorMockRecorder
 }
 
-// MockChecksumCalculatorMockRecorder is the mock recorder for MockChecksumCalculator
+// MockChecksumCalculatorMockRecorder is the mock recorder for MockChecksumCalculator.
 type MockChecksumCalculatorMockRecorder struct {
 	mock *MockChecksumCalculator
 }
 
-// NewMockChecksumCalculator creates a new mock instance
+// NewMockChecksumCalculator creates a new mock instance.
 func NewMockChecksumCalculator(ctrl *gomock.Controller) *MockChecksumCalculator {
 	mock := &MockChecksumCalculator{ctrl: ctrl}
 	mock.recorder = &MockChecksumCalculatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockChecksumCalculator) EXPECT() *MockChecksumCalculatorMockRecorder {
 	return m.recorder
 }
 
-// SuggestTalismanRC mocks base method
-func (m *MockChecksumCalculator) SuggestTalismanRC(fileNamePatterns []string) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SuggestTalismanRC", fileNamePatterns)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// SuggestTalismanRC indicates an expected call of SuggestTalismanRC
-func (mr *MockChecksumCalculatorMockRecorder) SuggestTalismanRC(fileNamePatterns interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuggestTalismanRC", reflect.TypeOf((*MockChecksumCalculator)(nil).SuggestTalismanRC), fileNamePatterns)
-}
-
-// CalculateCollectiveChecksumForPattern mocks base method
+// CalculateCollectiveChecksumForPattern mocks base method.
 func (m *MockChecksumCalculator) CalculateCollectiveChecksumForPattern(fileNamePattern string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalculateCollectiveChecksumForPattern", fileNamePattern)
@@ -54,8 +41,22 @@ func (m *MockChecksumCalculator) CalculateCollectiveChecksumForPattern(fileNameP
 	return ret0
 }
 
-// CalculateCollectiveChecksumForPattern indicates an expected call of CalculateCollectiveChecksumForPattern
+// CalculateCollectiveChecksumForPattern indicates an expected call of CalculateCollectiveChecksumForPattern.
 func (mr *MockChecksumCalculatorMockRecorder) CalculateCollectiveChecksumForPattern(fileNamePattern interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateCollectiveChecksumForPattern", reflect.TypeOf((*MockChecksumCalculator)(nil).CalculateCollectiveChecksumForPattern), fileNamePattern)
+}
+
+// SuggestTalismanRC mocks base method.
+func (m *MockChecksumCalculator) SuggestTalismanRC(fileNamePatterns []string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SuggestTalismanRC", fileNamePatterns)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SuggestTalismanRC indicates an expected call of SuggestTalismanRC.
+func (mr *MockChecksumCalculatorMockRecorder) SuggestTalismanRC(fileNamePatterns interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuggestTalismanRC", reflect.TypeOf((*MockChecksumCalculator)(nil).SuggestTalismanRC), fileNamePatterns)
 }

--- a/internal/mock/prompt/survey.go
+++ b/internal/mock/prompt/survey.go
@@ -5,34 +5,35 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockPrompt is a mock of Prompt interface
+// MockPrompt is a mock of Prompt interface.
 type MockPrompt struct {
 	ctrl     *gomock.Controller
 	recorder *MockPromptMockRecorder
 }
 
-// MockPromptMockRecorder is the mock recorder for MockPrompt
+// MockPromptMockRecorder is the mock recorder for MockPrompt.
 type MockPromptMockRecorder struct {
 	mock *MockPrompt
 }
 
-// NewMockPrompt creates a new mock instance
+// NewMockPrompt creates a new mock instance.
 func NewMockPrompt(ctrl *gomock.Controller) *MockPrompt {
 	mock := &MockPrompt{ctrl: ctrl}
 	mock.recorder = &MockPromptMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPrompt) EXPECT() *MockPromptMockRecorder {
 	return m.recorder
 }
 
-// Confirm mocks base method
+// Confirm mocks base method.
 func (m *MockPrompt) Confirm(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Confirm", arg0)
@@ -40,7 +41,7 @@ func (m *MockPrompt) Confirm(arg0 string) bool {
 	return ret0
 }
 
-// Confirm indicates an expected call of Confirm
+// Confirm indicates an expected call of Confirm.
 func (mr *MockPromptMockRecorder) Confirm(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Confirm", reflect.TypeOf((*MockPrompt)(nil).Confirm), arg0)

--- a/internal/mock/utility/sha_256_hasher.go
+++ b/internal/mock/utility/sha_256_hasher.go
@@ -5,34 +5,35 @@
 package mock
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockSHA256Hasher is a mock of SHA256Hasher interface
+// MockSHA256Hasher is a mock of SHA256Hasher interface.
 type MockSHA256Hasher struct {
 	ctrl     *gomock.Controller
 	recorder *MockSHA256HasherMockRecorder
 }
 
-// MockSHA256HasherMockRecorder is the mock recorder for MockSHA256Hasher
+// MockSHA256HasherMockRecorder is the mock recorder for MockSHA256Hasher.
 type MockSHA256HasherMockRecorder struct {
 	mock *MockSHA256Hasher
 }
 
-// NewMockSHA256Hasher creates a new mock instance
+// NewMockSHA256Hasher creates a new mock instance.
 func NewMockSHA256Hasher(ctrl *gomock.Controller) *MockSHA256Hasher {
 	mock := &MockSHA256Hasher{ctrl: ctrl}
 	mock.recorder = &MockSHA256HasherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSHA256Hasher) EXPECT() *MockSHA256HasherMockRecorder {
 	return m.recorder
 }
 
-// CollectiveSHA256Hash mocks base method
+// CollectiveSHA256Hash mocks base method.
 func (m *MockSHA256Hasher) CollectiveSHA256Hash(paths []string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CollectiveSHA256Hash", paths)
@@ -40,8 +41,36 @@ func (m *MockSHA256Hasher) CollectiveSHA256Hash(paths []string) string {
 	return ret0
 }
 
-// CollectiveSHA256Hash indicates an expected call of CollectiveSHA256Hash
+// CollectiveSHA256Hash indicates an expected call of CollectiveSHA256Hash.
 func (mr *MockSHA256HasherMockRecorder) CollectiveSHA256Hash(paths interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectiveSHA256Hash", reflect.TypeOf((*MockSHA256Hasher)(nil).CollectiveSHA256Hash), paths)
+}
+
+// Shutdown mocks base method.
+func (m *MockSHA256Hasher) Shutdown() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Shutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Shutdown indicates an expected call of Shutdown.
+func (mr *MockSHA256HasherMockRecorder) Shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockSHA256Hasher)(nil).Shutdown))
+}
+
+// Start mocks base method.
+func (m *MockSHA256Hasher) Start() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockSHA256HasherMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSHA256Hasher)(nil).Start))
 }

--- a/mock_scripts
+++ b/mock_scripts
@@ -1,8 +1,23 @@
 #! /usr/bin/env bash
 
-set -ex
+install_mockgen() {
+    pushd ..
+    go install github.com/golang/mock/mockgen@latest
+    popd
+}
 
+generate_mock() {
+    FILE=$1
+    mockgen -destination internal/mock/$FILE -package mock -source $FILE
+}
+
+set -ex
+#Ensure mockgen exists
+which mockgen || install_mockgen
 mkdir -p internal/mock
 
 # Mock for survey package
-mockgen -destination internal/mock/prompt/survey.go -package mock -source prompt/survey.go
+
+generate_mock prompt/survey.go
+generate_mock checksumcalculator/checksumcalculator.go
+generate_mock utility/sha_256_hasher.go

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"strings"
 	"talisman/gitrepo"
+	"talisman/utility"
+	"os"
 
 	"github.com/sirupsen/logrus"
 )
@@ -43,15 +45,19 @@ func GetAdditions(ignoreHistory bool, br gitrepo.BatchReader) []gitrepo.Addition
 }
 
 func getBlobsInCommit(ignoreHistory bool) BlobsInCommits {
+	progressBar := utility.GetProgressBar(os.Stdout, "Talisman Fetch Blobs")
 	commits := getAllCommits(ignoreHistory)
+	progressBar.Start(len(commits) - 1)
 	blobsInCommits := newBlobsInCommit()
 	result := make(chan []string, len(commits))
 	for _, commit := range commits {
 		go putBlobsInChannel(commit, result)
 	}
 	for i := 1; i < len(commits); i++ {
+		progressBar.Increment()
 		getBlobsFromChannel(blobsInCommits, result)
 	}
+	progressBar.Finish()
 	return blobsInCommits
 }
 

--- a/talismanrc/entry-point.go
+++ b/talismanrc/entry-point.go
@@ -1,9 +1,8 @@
 package talismanrc
 
 import (
-	"os"
 	"regexp"
-	"talisman/gitrepo"
+	"talisman/utility"
 
 	logr "github.com/sirupsen/logrus"
 
@@ -55,9 +54,14 @@ func SetRcFilename__(rcFileName string) {
 type RepoFileReader func(string) ([]byte, error)
 
 var repoFileReader = func() RepoFileReader {
-	wd, _ := os.Getwd()
-	repo := gitrepo.RepoLocatedAt(wd)
-	return repo.ReadRepoFileOrNothing
+
+	return func(path string) ([]byte, error) {
+		data, err := utility.SafeReadFile(path)
+		if err != nil {
+			return []byte{}, nil
+		}
+		return data, nil
+	}
 }
 
 func setRepoFileReader(rfr RepoFileReader) {

--- a/utility/progress_bar.go
+++ b/utility/progress_bar.go
@@ -1,0 +1,53 @@
+package utility
+
+import (
+	"os"
+
+	"github.com/cheggaaa/pb/v3"
+)
+
+func GetProgressBar() progressBar {
+	if isTerminal() {
+		return &defaultProgressBar{}
+	} else {
+		return &noOpProgressBar{}
+	}
+}
+
+func isTerminal() bool {
+	fileInfo, _ := os.Stdout.Stat()
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
+type progressBar interface {
+	Start(int)
+	Increment()
+	Finish()
+}
+
+type noOpProgressBar struct {
+}
+
+func (d *noOpProgressBar) Start(int) {}
+
+func (d *noOpProgressBar) Increment() {}
+
+func (d *noOpProgressBar) Finish() {}
+
+type defaultProgressBar struct {
+	bar *pb.ProgressBar
+}
+
+func (d *defaultProgressBar) Start(total int) {
+	bar := pb.ProgressBarTemplate(`{{ red "Talisman Scan:" }} {{counters .}} {{ bar . "<" "-" (cycle . "↖" "↗" "↘" "↙" ) "." ">"}} {{percent . | rndcolor }} {{green}} {{blue}}`).New(total)
+	bar.Set(pb.Terminal, true)
+	d.bar = bar.Start()
+}
+
+func (d *defaultProgressBar) Increment() {
+	d.bar.Increment()
+}
+
+func (d *defaultProgressBar) Finish() {
+	d.bar.Finish()
+}

--- a/utility/progress_bar.go
+++ b/utility/progress_bar.go
@@ -6,16 +6,16 @@ import (
 	"github.com/cheggaaa/pb/v3"
 )
 
-func GetProgressBar() progressBar {
-	if isTerminal() {
+func GetProgressBar(out *os.File) progressBar {
+	if isTerminal(out) {
 		return &defaultProgressBar{}
 	} else {
 		return &noOpProgressBar{}
 	}
 }
 
-func isTerminal() bool {
-	fileInfo, _ := os.Stdout.Stat()
+func isTerminal(out *os.File) bool {
+	fileInfo, _ := out.Stat()
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 

--- a/utility/progress_bar.go
+++ b/utility/progress_bar.go
@@ -1,14 +1,15 @@
 package utility
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cheggaaa/pb/v3"
 )
 
-func GetProgressBar(out *os.File) progressBar {
+func GetProgressBar(out *os.File, title string) progressBar {
 	if isTerminal(out) {
-		return &defaultProgressBar{}
+		return &defaultProgressBar{title: title}
 	} else {
 		return &noOpProgressBar{}
 	}
@@ -36,10 +37,12 @@ func (d *noOpProgressBar) Finish() {}
 
 type defaultProgressBar struct {
 	bar *pb.ProgressBar
+	title string
 }
 
 func (d *defaultProgressBar) Start(total int) {
-	bar := pb.ProgressBarTemplate(`{{ red "Talisman Scan:" }} {{counters .}} {{ bar . "<" "-" (cycle . "↖" "↗" "↘" "↙" ) "." ">"}} {{percent . | rndcolor }} {{green}} {{blue}}`).New(total)
+	template := fmt.Sprintf(`{{ red "%s:" }} {{counters .}} {{ bar . "<" "-" (cycle . "↖" "↗" "↘" "↙" ) "." ">"}} {{percent . | rndcolor }} {{green}} {{blue}}`, d.title)
+	bar := pb.ProgressBarTemplate(template).New(total)
 	bar.Set(pb.Terminal, true)
 	d.bar = bar.Start()
 }

--- a/utility/progress_bar_test.go
+++ b/utility/progress_bar_test.go
@@ -1,0 +1,38 @@
+package utility
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultProgressBar(t *testing.T) {
+	t.Run("Start should start inner progress bar", func(t *testing.T) {
+		progressBar := &defaultProgressBar{}
+
+		progressBar.Start(10)
+
+		assert.True(t, progressBar.bar.IsStarted())
+	})
+
+	t.Run("Increment should update inner progress bar", func(t *testing.T) {
+		progressBar := &defaultProgressBar{}
+
+		progressBar.Start(10)
+		progressBar.Increment()
+
+		assert.Equal(t, int64(1), progressBar.bar.Current())
+	})
+
+	t.Run("Finish should finish progress bar", func(t *testing.T) {
+		progressBar := &defaultProgressBar{}
+
+		progressBar.Start(2)
+		progressBar.Increment()
+		progressBar.Increment()
+		progressBar.Finish()
+
+		assert.False(t, progressBar.bar.IsStarted())
+	})
+
+}

--- a/utility/progress_bar_test.go
+++ b/utility/progress_bar_test.go
@@ -34,5 +34,4 @@ func TestDefaultProgressBar(t *testing.T) {
 
 		assert.False(t, progressBar.bar.IsStarted())
 	})
-
 }

--- a/utility/sha_256_hasher.go
+++ b/utility/sha_256_hasher.go
@@ -17,15 +17,27 @@ func (DefaultSHA256Hasher) CollectiveSHA256Hash(paths []string) string {
 	return collectiveSHA256Hash(paths, SafeReadFile)
 }
 
-type GitHeadSHA256Hasher struct {
+type GitHeadFileSHA256Hasher struct {
 	root string
 }
 
-func NewGitHeadSHA256Hasher(root string) GitHeadSHA256Hasher {
-	return GitHeadSHA256Hasher{root}
+type GitFileSHA256Hasher struct {
+	root string
 }
 
-func (g GitHeadSHA256Hasher) CollectiveSHA256Hash(paths []string) string {
+func NewGitHeadFileSHA256Hasher(root string) GitHeadFileSHA256Hasher {
+	return GitHeadFileSHA256Hasher{root}
+}
+
+func NewGitFileSHA256Hasher(root string) GitFileSHA256Hasher {
+	return GitFileSHA256Hasher{root}
+}
+
+func (g GitHeadFileSHA256Hasher) CollectiveSHA256Hash(paths []string) string {
+	return collectiveSHA256Hash(paths, gitrepo.NewCommittedRepoFileReader(g.root))
+}
+
+func (g GitFileSHA256Hasher) CollectiveSHA256Hash(paths []string) string {
 	return collectiveSHA256Hash(paths, gitrepo.NewRepoFileReader(g.root))
 }
 


### PR DESCRIPTION
Introduce and use different kinds of file readers based on git cat-file for checksum calculation
Batched git hashers that read
1. staged versions of file
2. latest committed(HEAD) version of file
3. raw git objects