### PR TITLE
Allow set SEARCH_ROOT outside the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ If you choose to set the `$PATH` later, please export TALISMAN\_HOME=$HOME/.tali
 
 3. Choose a base directory where Talisman should scan for all git repositories, and setup a git hook (pre-commit or pre-push, as chosen in step 1) as a symlink.
   This script will not clobber pre-existing hooks. If you have existing hooks, [look for ways to chain Talisman into them.](#handling-existing-hooks)
+  
+  - you can set SEARCH_ROOT environment variable with the path of the base directory before executing the installation so you don't need to input it manually during the installation
 
 
 ### Handling existing hooks

--- a/global_install_scripts/install.bash
+++ b/global_install_scripts/install.bash
@@ -4,6 +4,7 @@ shopt -s extglob
 
 DEBUG=${DEBUG:-''}
 FORCE_DOWNLOAD=${FORCE_DOWNLOAD:-''}
+SEARCH_ROOT=${SEARCH_ROOT:-''}
 
 # default is a pre-commit hook; if "pre-push" is the first arg to the script, then it sets up as pre-push
 declare HOOK_SCRIPT='pre-commit'

--- a/global_install_scripts/install.bash
+++ b/global_install_scripts/install.bash
@@ -408,7 +408,10 @@ END_OF_SCRIPT
 	setup_git_template_talisman_hook
 	echo
 	echo "Setting up talisman hook recursively in git repos"
-	read -p "Please enter root directory to search for git repos (Default: ${HOME}): " SEARCH_ROOT
+	
+	if [[ "$SEARCH_ROOT" == "" ]]; then
+		read -p "Please enter root directory to search for git repos (Default: ${HOME}): " SEARCH_ROOT
+	fi
 	SEARCH_ROOT=${SEARCH_ROOT:-$HOME}
 	setup_git_talisman_hooks_at $SEARCH_ROOT
 }


### PR DESCRIPTION
This is for allowing the script to be used inside automated
environment, instead of someone manually installing talisman