### PR TITLE
Support for PHP scope

### DIFF
--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -6,6 +6,6 @@ var knownScopes = map[string][]string{
 	"images":    {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 	"bazel":     {"*.bzl"},
 	"terraform": {".terraform.lock.hcl"},
-	"php":       {"composer.lock", "vendor/"},
+	"php":       {"composer.lock"},
 	"python":    {"poetry.lock", "Pipfile.lock"},
 }

--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -6,4 +6,5 @@ var knownScopes = map[string][]string{
 	"images":    {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 	"bazel":     {"*.bzl"},
 	"terraform": {".terraform.lock.hcl"},
+	"php":       {"composer.lock", "vendor/"},
 }

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -89,7 +89,7 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 		},
 		"php": {
 			testAddition("composer.lock"),
-			testAddition("vendor/foo/bar/App.php")},
+		},
 		"python": {
 			testAddition("poetry.lock"),
 			testAddition("Pipfile.lock"),

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -87,6 +87,9 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 			testAddition("foo/.terraform.lock.hcl"),
 			testAddition("foo/bar/.terraform.lock.hcl"),
 		},
+		"php": {
+			testAddition("composer.lock"),
+			testAddition("vendor/foo/bar/App.php")},
 	}
 
 	for scopeName, additions := range testTable {


### PR DESCRIPTION
Hi,
I am using Talisman on a PHP project, the composer lock file contains lots of hashes which are always ok as it is autogenerated.
Would be great to add support for PHP scope.
Keith