### PR TITLE
Override user's `diff.noprefix` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Talisman CLI tool `talisman` also comes with the capability to provide detailed 
 
 * `talisman --scanWithHtml`
 
-This will scan the repository and create a folder `talisman_html_report` under the the scanned repository. We need to start an HTTP server inside this repository to access the report.Below is a recommended approach to start a HTTP server:
+This will scan the repository and create a folder `talisman_html_report` under the scanned repository. We need to start an HTTP server inside this repository to access the report.Below is a recommended approach to start a HTTP server:
 
 * `python -m SimpleHTTPServer <port> (eg: 8000)`
 

--- a/contributing.md
+++ b/contributing.md
@@ -38,7 +38,7 @@ To send in a pull request
 
 1. Fork the repo.
 2. Create a new feature branch based off the master branch.
-3. Provide the commit message with the the issue number and a proper description.
+3. Provide the commit message with the issue number and a proper description.
 4. Ensure that all the tests pass.
 5. Submit the pull request.
 

--- a/gitrepo/gitrepo.go
+++ b/gitrepo/gitrepo.go
@@ -40,7 +40,7 @@ func RepoLocatedAt(path string) GitRepo {
 
 // GetDiffForStagedFiles gets all the staged files and collects the diff section in each file
 func (repo GitRepo) GetDiffForStagedFiles() []Addition {
-	stagedContent := repo.executeRepoCommand("git", "diff", "--staged")
+	stagedContent := repo.executeRepoCommand("git", "diff", "--staged", "--src-prefix=a/", "--dst-prefix=b/")
 	content := strings.TrimSpace(string(stagedContent))
 	lines := strings.Split(content, "\n")
 	result := make([]Addition, 0)


### PR DESCRIPTION
### Purpose
* Fix https://github.com/thoughtworks/talisman/issues/379
* Fix some typos on docs

### Approach
Override the user's `diff.noprefix` config by forcing talisman to add `src-prefix` and `dst-prefix` flags when calling `git diff`

### Screenshot
![Screenshot 2022-10-12 at 4 30 50 PM](https://user-images.githubusercontent.com/1910192/195310002-44d524e5-bc0a-4eb4-acfd-6bcf883e1c18.png)
