### PR TITLE
use same checksum logic for talismanRC suggestion as during detection

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -31,7 +31,7 @@ func (r *runner) Run(tRC *talismanrc.TalismanRC, promptContext prompt.PromptCont
 	setCustomSeverities(tRC)
 	additionsToScan := tRC.FilterAdditions(r.additions)
 	detector.DefaultChain(tRC, r.mode).Test(additionsToScan, tRC, r.results)
-	r.printReport(promptContext)
+	r.printReport(additionsToScan, promptContext)
 	exitStatus := r.exitStatus()
 	return exitStatus
 }
@@ -42,12 +42,12 @@ func setCustomSeverities(tRC *talismanrc.TalismanRC) {
 	}
 }
 
-func (r *runner) printReport(promptContext prompt.PromptContext) {
+func (r *runner) printReport(currentAdditions []gitrepo.Addition, promptContext prompt.PromptContext) {
 	if r.results.HasWarnings() {
 		fmt.Println(r.results.ReportWarnings())
 	}
 	if r.results.HasIgnores() || r.results.HasFailures() {
-		r.results.Report(promptContext, r.mode)
+		r.results.Report(currentAdditions, promptContext, r.mode)
 	}
 }
 


### PR DESCRIPTION
Resolves #416

With this PR the git additions used for the detection scan are also taken into account when reporting the checksum suggestions for the `.talismanrc` file. Because evaluation of `fileignoreconfig` checksums during detection scans is based on filename pattern matching against the git additions too. (see `ChecksumCompare.IsScanNotRequired()` and `ChecksumCalculator.CalculateCollectiveChecksumForPattern()`)

---
_The program was tested solely for our own use cases, which might differ from yours._  
_Frank Seidel <frank.seidel@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH_  
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)