### PR TITLE
use existing path matching logic when filtering allowed patterns on file configs

### DIFF
--- a/detector/helpers/checksum_compare.go
+++ b/detector/helpers/checksum_compare.go
@@ -23,8 +23,10 @@ func (cc *ChecksumCompare) IsScanNotRequired(addition gitrepo.Addition) bool {
 	for _, ignore := range cc.talismanRC.IgnoreConfigs {
 		if addition.Matches(ignore.GetFileName()) {
 			currentCollectiveChecksum = cc.calculator.CalculateCollectiveChecksumForPattern(ignore.GetFileName())
-			return ignore.ChecksumMatches(currentCollectiveChecksum)
+			if ignore.ChecksumMatches(currentCollectiveChecksum) {
+				return true
+			}
 		}
 	}
-	return false;
+	return false
 }

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -165,8 +165,7 @@ func (tRC *TalismanRC) Deny(addition gitrepo.Addition, detectorName string) bool
 }
 
 //Strip git addition 
-func(tRC *TalismanRC) FilterAllowedPatternsFromAddition(addition gitrepo.Addition) string {
-	additionPathAsString := string(addition.Path)
+func (tRC *TalismanRC) FilterAllowedPatternsFromAddition(addition gitrepo.Addition) string {
 	// Processing global allowed patterns
 	for _, pattern := range tRC.AllowedPatterns {
 		addition.Data = pattern.ReplaceAll(addition.Data, []byte(""))
@@ -174,7 +173,7 @@ func(tRC *TalismanRC) FilterAllowedPatternsFromAddition(addition gitrepo.Additio
 
 	// Processing allowed patterns based on file path
 	for _, ignoreConfig := range tRC.IgnoreConfigs {
-		if ignoreConfig.GetFileName() == additionPathAsString {
+		if addition.Matches(ignoreConfig.GetFileName()) {
 			for _, pattern := range ignoreConfig.GetAllowedPatterns() {
 				addition.Data = pattern.ReplaceAll(addition.Data, []byte(""))
 			}

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -73,6 +73,20 @@ func TestShouldFilterAllowedPatternsFromAdditionBasedOnFileConfig(t *testing.T) 
 	assert.Equal(t, fileContentFiltered2, fileContent)
 }
 
+func TestShouldFilterAllowedPatternsFromAdditionBasedOnFileConfigWithWildcards(t *testing.T) {
+	const hexContent string = "68656C6C6F20776F726C6421"
+	const fileContent string = "Prefix content" + hexContent
+	gitRepoAddition1 := testAdditionWithData("foo/file1.yml", []byte(fileContent))
+	gitRepoAddition2 := testAdditionWithData("foo/file2.yml", []byte(fileContent))
+	talismanrc := createTalismanRCWithFileIgnores("foo/*.yml", "somedetector", []string{hexContent})
+
+	fileContentFiltered1 := talismanrc.FilterAllowedPatternsFromAddition(gitRepoAddition1)
+	fileContentFiltered2 := talismanrc.FilterAllowedPatternsFromAddition(gitRepoAddition2)
+
+	assert.Equal(t, fileContentFiltered1, "Prefix content")
+	assert.Equal(t, fileContentFiltered2, "Prefix content")
+}
+
 func TestShouldConvertThresholdToValue(t *testing.T) {
 	talismanRCContents := []byte("threshold: high")
 	assert.Equal(t, newPersistedRC(talismanRCContents).Threshold, severity.High)
@@ -299,8 +313,6 @@ func TestFor(t *testing.T) {
 		assert.True(t, rc.IgnoreConfigs[2].ChecksumMatches("file3_checksum"))
 
 	})
-
-
 }
 
 func TestForScan(t *testing.T) {


### PR DESCRIPTION
Resolves #414

This PR adds the possibility to use `allowed_patterns` together with file path wildcards in the `fileignoreconfig`, while still allowing file specific checksum-based ignore configs - as printed  by the githook reports.

For example, something like this would be possible:
```
fileignoreconfig:
- filename: 'sub-folder/*.yml'
  allowed_patterns: [key]
- filename: sub-folder/foo.yml
  checksum: a21f3d967b236bd1ae3d056323c7ee054ac63b2b374dd1864d8bba21169b2b33 
```

---
_The program was tested solely for our own use cases, which might differ from yours._  
_Frank Seidel <frank.seidel@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH_  
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)