### PR TITLE
Fix typo by replacing 'Expected file to not to' as 'Expected file to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Talisman Report:
 |                 | failed checks against the                                                     |
 |                 | pattern ^.+\.pem$                                                             |
 +-----------------+-------------------------------------------------------------------------------+
-| danger.pem      | Expected file to not to contain hex encoded texts such as:                    |
+| danger.pem      | Expected file to not contain hex encoded texts such as:                    |
 |                 | awsSecretKey=c64e8c79aacf5ddb02f1274db2d973f363f4f553ab1692d8d203b4cc09692f79 |
 +-----------------+-------------------------------------------------------------------------------+
 ```

--- a/detector/filecontent/base64_aggressive_detector_test.go
+++ b/detector/filecontent/base64_aggressive_detector_test.go
@@ -29,7 +29,7 @@ func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 			results,
 			dummyCompletionCallbackFunc)
 
-	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t *testing.T) {
@@ -46,7 +46,7 @@ func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t 
 			results,
 			dummyCompletionCallbackFunc)
 
-	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *testing.T) {
@@ -68,5 +68,5 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *
 			results,
 			dummyCompletionCallbackFunc)
 
-	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }

--- a/detector/filecontent/base64_aggressive_detector_test.go
+++ b/detector/filecontent/base64_aggressive_detector_test.go
@@ -29,7 +29,7 @@ func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 			results,
 			dummyCompletionCallbackFunc)
 
-	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t *testing.T) {
@@ -46,7 +46,7 @@ func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t 
 			results,
 			dummyCompletionCallbackFunc)
 
-	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *testing.T) {
@@ -68,5 +68,5 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *
 			results,
 			dummyCompletionCallbackFunc)
 
-	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }

--- a/detector/filecontent/filecontent_detector.go
+++ b/detector/filecontent/filecontent_detector.go
@@ -58,11 +58,11 @@ func (ct contentType) getInfo() string {
 func (ct contentType) getMessageFormat() string {
 	switch ct {
 	case base64Content:
-		return "Expected file to not to contain base64 encoded texts such as: %s"
+		return "Expected file to not contain base64 encoded texts such as: %s"
 	case hexContent:
-		return "Expected file to not to contain hex encoded texts such as: %s"
+		return "Expected file to not contain hex encoded texts such as: %s"
 	case creditCardContent:
-		return "Expected file to not to contain credit card numbers such as: %s"
+		return "Expected file to not contain credit card numbers such as: %s"
 	}
 
 	return ""

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -29,7 +29,7 @@ func TestShouldNotFlagSafeText(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldIgnoreFileIfNeeded(t *testing.T) {
@@ -63,7 +63,7 @@ func TestShouldNotFlag4CharSafeText(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldNotFlagLowEntropyBase64Text(t *testing.T) {
@@ -74,7 +74,7 @@ func TestShouldNotFlagLowEntropyBase64Text(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
@@ -88,7 +88,7 @@ func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
 
 	expectedMessage := fmt.
 		Sprintf("Expected file to not contain base64 encoded texts such as: %s", awsSecretAccessKey)
-	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -103,7 +103,7 @@ func TestShouldFlagPotentialSecretWithoutTrimmingWhenLengthLessThan50Characters(
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 
 	expectedMessage := fmt.Sprintf("Expected file to not contain base64 encoded texts such as: %s", secret)
-	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -121,7 +121,7 @@ func TestShouldFlagPotentialJWT(t *testing.T) {
 
 	expectedMessage := fmt.
 		Sprintf("Expected file to not contain base64 encoded texts such as: %s", jwt[:47]+"...")
-	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -143,7 +143,7 @@ func TestShouldFlagPotentialSecretsWithinJavaCode(t *testing.T) {
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 	expectedMessage := "Expected file to not contain base64 encoded texts such as: " +
 		"accessKey=\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPL..."
-	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -160,7 +160,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCode(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldNotFlagPotentialSecretsWithinSafeLongMethodName(t *testing.T) {
@@ -170,7 +170,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeLongMethodName(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts.")
 }
 
 func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -29,7 +29,7 @@ func TestShouldNotFlagSafeText(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldIgnoreFileIfNeeded(t *testing.T) {
@@ -63,7 +63,7 @@ func TestShouldNotFlag4CharSafeText(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldNotFlagLowEntropyBase64Text(t *testing.T) {
@@ -74,7 +74,7 @@ func TestShouldNotFlagLowEntropyBase64Text(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
@@ -87,8 +87,8 @@ func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 
 	expectedMessage := fmt.
-		Sprintf("Expected file to not to contain base64 encoded texts such as: %s", awsSecretAccessKey)
-	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+		Sprintf("Expected file to not contain base64 encoded texts such as: %s", awsSecretAccessKey)
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -102,8 +102,8 @@ func TestShouldFlagPotentialSecretWithoutTrimmingWhenLengthLessThan50Characters(
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 
-	expectedMessage := fmt.Sprintf("Expected file to not to contain base64 encoded texts such as: %s", secret)
-	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	expectedMessage := fmt.Sprintf("Expected file to not contain base64 encoded texts such as: %s", secret)
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -120,8 +120,8 @@ func TestShouldFlagPotentialJWT(t *testing.T) {
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 
 	expectedMessage := fmt.
-		Sprintf("Expected file to not to contain base64 encoded texts such as: %s", jwt[:47]+"...")
-	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+		Sprintf("Expected file to not contain base64 encoded texts such as: %s", jwt[:47]+"...")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -141,9 +141,9 @@ func TestShouldFlagPotentialSecretsWithinJavaCode(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	expectedMessage := "Expected file to not to contain base64 encoded texts such as: " +
+	expectedMessage := "Expected file to not contain base64 encoded texts such as: " +
 		"accessKey=\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPL..."
-	assert.True(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.True(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -160,7 +160,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCode(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldNotFlagPotentialSecretsWithinSafeLongMethodName(t *testing.T) {
@@ -170,7 +170,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeLongMethodName(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	assert.False(t, results.HasFailures(), "Expected file to not to contain base64 encoded texts")
+	assert.False(t, results.HasFailures(), "Expected file to not contain base64 encoded texts")
 }
 
 func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
@@ -181,7 +181,7 @@ func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
+	expectedMessage := "Expected file to not contain hex encoded texts such as: " + hex
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }
@@ -243,7 +243,7 @@ func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
-	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
+	expectedMessage := "Expected file to not contain hex encoded texts such as: " + hex
 	messageReceived := strings.Join(getFailureMessages(results, filePath), " ")
 	assert.Regexp(t, expectedMessage, messageReceived, "Should contain hex detection message")
 	assert.Len(t, results.Results, 1)
@@ -260,7 +260,7 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 
-	expectedMessage := "Expected file to not to contain base64 encoded texts such as: " + base64
+	expectedMessage := "Expected file to not contain base64 encoded texts such as: " + base64
 	messageReceived := strings.Join(getFailureMessages(results, filePath), " ")
 	assert.Regexp(t, expectedMessage, messageReceived, "Should contain base64 detection message")
 	assert.Len(t, results.Results, 1)
@@ -275,7 +275,7 @@ func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *te
 	NewFileContentDetector(emptyTalismanRC).
 		Test(defaultChecksumCompareUtility, additions, emptyTalismanRC, results, dummyCallback)
 
-	expectedMessage := "Expected file to not to contain credit card numbers such as: " + creditCardNumber
+	expectedMessage := "Expected file to not contain credit card numbers such as: " + creditCardNumber
 	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 	assert.Len(t, results.Results, 1)
 }

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -29,7 +29,7 @@ func TestShouldNotFlagLargeFilesIfThresholdIsBelowSeverity(t *testing.T) {
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
 	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, defaultHasher, talismanRCWithThreshold), additions, talismanRCWithThreshold, results, func() {})
-	assert.False(t, results.HasFailures(), "Expected file to not to fail the check against file size detector.")
+	assert.False(t, results.HasFailures(), "Expected file to not fail the check against file size detector.")
 	assert.True(t, results.HasWarnings(), "Expected file to have warnings against file size detector.")
 }
 
@@ -38,7 +38,7 @@ func TestShouldNotFlagSmallFiles(t *testing.T) {
 	content := []byte("m")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
 	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, defaultHasher, talismanRC), additions, talismanRC, results, func() {})
-	assert.False(t, results.HasFailures(), "Expected file to not to fail the check against file size detector.")
+	assert.False(t, results.HasFailures(), "Expected file to not fail the check against file size detector.")
 }
 
 func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {


### PR DESCRIPTION
Fixed typo by replacing 'Expected file to not to' as 'Expected file to not' for improved readability