### PR TITLE
Add pnpm-lock.yml to talismanrc

### DIFF
--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -1,7 +1,7 @@
 package talismanrc
 
 var knownScopes = map[string][]string{
-	"node":      {"pnpm.lock", "yarn.lock", "package-lock.json", "node_modules/"},
+	"node":      {"pnpm-lock.yaml", "yarn.lock", "package-lock.json", "node_modules/"},
 	"go":        {"makefile", "go.mod", "go.sum", "Gopkg.toml", "Gopkg.lock", "glide.yaml", "glide.lock"},
 	"images":    {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 	"bazel":     {"*.bzl"},

--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -1,7 +1,7 @@
 package talismanrc
 
 var knownScopes = map[string][]string{
-	"node":      {"yarn.lock", "package-lock.json", "node_modules/"},
+	"node":      {"pnpm.lock", "yarn.lock", "package-lock.json", "node_modules/"},
 	"go":        {"makefile", "go.mod", "go.sum", "Gopkg.toml", "Gopkg.lock", "glide.yaml", "glide.lock"},
 	"images":    {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 	"bazel":     {"*.bzl"},

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -90,6 +90,7 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 	testTable := map[string][]gitrepo.Addition{
 		"node": {
 			testAddition("yarn.lock"),
+			testAddition("pnpm.lock"),
 			testAddition("package-lock.json"),
 			testAddition("node_modules/module1/foo.js")},
 		"go": {

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -90,7 +90,7 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 	testTable := map[string][]gitrepo.Addition{
 		"node": {
 			testAddition("yarn.lock"),
-			testAddition("pnpm.lock"),
+			testAddition("pnpm-lock.yaml"),
 			testAddition("package-lock.json"),
 			testAddition("node_modules/module1/foo.js")},
 		"go": {


### PR DESCRIPTION
I'm adding support for `pnpm-lock.yml` when the node scope is enabled. This could be useful as many people use pnpm and might not want to have to manually ignore it every time the lockfile changes