### PR TITLE
Add instructions to install Talisman on Windows using WinGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ command in terminal:
 brew install talisman
 ```
 
+On Windows you can use WinGet by running the following command in a terminal:
+
+```
+winget install --id Thoughtworks.Talisman
+```
+
 ## Installation as a global hook template
 
 We offer scripts that will install Talisman as a **pre-commit git hook template**, as that will cause


### PR DESCRIPTION
Talisman can be installed with [WinGet](https://learn.microsoft.com/en-gb/windows/package-manager/) on Windows (similar to Homebrew/linuxbrew).