### PR TITLE
Fix issue where CustomSeverities are not respected in config

### DIFF
--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -201,6 +201,7 @@ func fromPersistedRC(configFromTalismanRCFile *persistedRC, mode Mode) *Talisman
 	tRC.ScopeConfig = configFromTalismanRCFile.ScopeConfig
 	tRC.Experimental = configFromTalismanRCFile.Experimental
 	tRC.CustomPatterns = configFromTalismanRCFile.CustomPatterns
+	tRC.CustomSeverities = configFromTalismanRCFile.CustomSeverities
 	tRC.Experimental = configFromTalismanRCFile.Experimental
 	tRC.AllowedPatterns = make([]*regexp.Regexp, len(configFromTalismanRCFile.AllowedPatterns))
 	for i, p := range configFromTalismanRCFile.AllowedPatterns {

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -78,6 +78,19 @@ func TestShouldConvertThresholdToValue(t *testing.T) {
 	assert.Equal(t, newPersistedRC(talismanRCContents).Threshold, severity.High)
 }
 
+func TestObeysCustomSeverityLevelsAndThreshold(t *testing.T) {
+	talismanRCContents := []byte(`threshold: high
+custom_severities:
+- detector: Base64Content
+  severity: low
+`)
+	persistedRC := newPersistedRC(talismanRCContents)
+	talismanRC := fromPersistedRC(persistedRC, ScanMode)
+	assert.Equal(t, newPersistedRC(talismanRCContents).Threshold, severity.High)
+	assert.Equal(t, len(newPersistedRC(talismanRCContents).CustomSeverities), 1)
+	assert.Equal(t, persistedRC.CustomSeverities, talismanRC.CustomSeverities)
+}
+
 func TestDirectoryPatterns(t *testing.T) {
 	assertAccepts("foo/", "", "bar", t)
 	assertAccepts("foo/", "", "foo", t)


### PR DESCRIPTION
Original ability was added in: https://github.com/thoughtworks/talisman/pull/281

When trying out the functionality, it does not respect custom_severities as documented in the README.

This patch addresses it by including the porting of custom severities from the the same location where other config keys are copied

I've confirmed that it works both in a new test and in manual regression testing.

Fixes: https://github.com/thoughtworks/talisman/issues/364

Side note: I didn't include further changes but it looks like golang is auto-formatting code in the project differently than what's committed in the files I touched. It's a good idea to do a single code formatting re-write so you don't have a trickle of whitespace/formatting changes in PRs.