### PR TITLE
fix: pre-commit warning

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: talisman-commit
     name: talisman
     entry: talisman --githook pre-commit
-    stages: [commit]
+    stages: [pre-commit]
     # talisman currently discovers files by itself and does not take them on the cli
     pass_filenames: false
     types: [text]
@@ -10,7 +10,7 @@
 -   id: talisman-push
     name: talisman
     entry: talisman --githook pre-push
-    stages: [push]
+    stages: [pre-push]
     # talisman currently discovers files by itself and does not take them on the cli
     pass_filenames: false
     types: [text]


### PR DESCRIPTION
Updating to fix pre-commit warning

```
[INFO] Initializing environment for https://github.com/thoughtworks/talisman.
[WARNING] repo `https://github.com/thoughtworks/talisman` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/thoughtworks/talisman` will fix this.  if it does not -- consider reporting an issue to that repo.
```

https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

```
new in 3.2.0: The values of stages match the hook names. Previously, commit, push, and merge-commit matched pre-commit, pre-push, and pre-merge-commit respectively.
```