### PR TITLE
Introduce ignore evaluator

### DIFF
--- a/checksumcalculator/checksumcalculator.go
+++ b/checksumcalculator/checksumcalculator.go
@@ -15,17 +15,16 @@ type ChecksumCalculator interface {
 }
 
 type checksumCalculator struct {
-	gitAdditions []gitrepo.Addition
-	hasher       utility.SHA256Hasher
+	allTrackedFiles []gitrepo.Addition
+	hasher          utility.SHA256Hasher
 }
 
-//NewChecksumCalculator returns new instance of the CheckSumDetector
+// NewChecksumCalculator returns new instance of the CheckSumDetector
 func NewChecksumCalculator(hasher utility.SHA256Hasher, gitAdditions []gitrepo.Addition) ChecksumCalculator {
-	cc := checksumCalculator{hasher: hasher, gitAdditions: gitAdditions}
-	return &cc
+	return &checksumCalculator{hasher: hasher, allTrackedFiles: gitAdditions}
 }
 
-//SuggestTalismanRC returns the suggestion for .talismanrc format
+// SuggestTalismanRC returns the suggestion for .talismanrc format
 func (cc *checksumCalculator) SuggestTalismanRC(fileNamePatterns []string) string {
 	var fileIgnoreConfigs []talismanrc.FileIgnoreConfig
 	result := strings.Builder{}
@@ -45,13 +44,13 @@ func (cc *checksumCalculator) SuggestTalismanRC(fileNamePatterns []string) strin
 	return result.String()
 }
 
-//CalculateCollectiveChecksumForPattern calculates and returns the checksum for files matching the input pattern
+// CalculateCollectiveChecksumForPattern calculates and returns the checksum for files matching the input pattern
 func (cc *checksumCalculator) CalculateCollectiveChecksumForPattern(fileNamePattern string) string {
 	var patternPaths []string
 	currentCollectiveChecksum := ""
-	for _, addition := range cc.gitAdditions {
-		if addition.Matches(fileNamePattern) {
-			patternPaths = append(patternPaths, string(addition.Path))
+	for _, file := range cc.allTrackedFiles {
+		if file.Matches(fileNamePattern) {
+			patternPaths = append(patternPaths, string(file.Path))
 		}
 	}
 	// Calculate current collective checksum

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -31,12 +31,12 @@ func NewRunner(additions []gitrepo.Addition, mode string) *runner {
 func (r *runner) Run(tRC *talismanrc.TalismanRC, promptContext prompt.PromptContext) int {
 	wd, _ := os.Getwd()
 	repo := gitrepo.RepoLocatedAt(wd)
-	cc := helpers.BuildCC(r.mode, tRC, repo)
+	ie := helpers.BuildIgnoreEvaluator(r.mode, tRC, repo)
 
 	setCustomSeverities(tRC)
 	additionsToScan := tRC.FilterAdditions(r.additions)
 
-	detector.DefaultChain(tRC, cc).Test(additionsToScan, tRC, r.results)
+	detector.DefaultChain(tRC, ie).Test(additionsToScan, tRC, r.results)
 	r.printReport(promptContext)
 	exitStatus := r.exitStatus()
 	return exitStatus

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -24,12 +24,18 @@ type ScannerCmd struct {
 	reportDirectory string
 }
 
-//Run scans git commit history for potential secrets and returns 0 or 1 as exit code
+// Run scans git commit history for potential secrets and returns 0 or 1 as exit code
 func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 	fmt.Printf("\n\n")
 	utility.CreateArt("Running Scan..")
+
+	wd, _ := os.Getwd()
+	repo := gitrepo.RepoLocatedAt(wd)
+	cc := helpers.BuildCC("default", tRC, repo)
+
 	additionsToScan := tRC.FilterAdditions(s.additions)
-	detector.DefaultChain(tRC, "default").Test(additionsToScan, tRC, s.results)
+
+	detector.DefaultChain(tRC, cc).Test(additionsToScan, tRC, s.results)
 	reportsPath, err := report.GenerateReport(s.results, s.reportDirectory)
 	if err != nil {
 		logr.Errorf("error while generating report: %v", err)
@@ -47,7 +53,7 @@ func (s *ScannerCmd) exitStatus() int {
 	return EXIT_SUCCESS
 }
 
-//NewScannerCmd Returns a new scanner command
+// NewScannerCmd Returns a new scanner command
 func NewScannerCmd(ignoreHistory bool, reportDirectory string) *ScannerCmd {
 	repoRoot, _ := os.Getwd()
 	reader := gitrepo.NewBatchGitObjectHashReader(repoRoot)

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -31,11 +31,11 @@ func (s *ScannerCmd) Run(tRC *talismanrc.TalismanRC) int {
 
 	wd, _ := os.Getwd()
 	repo := gitrepo.RepoLocatedAt(wd)
-	cc := helpers.BuildCC("default", tRC, repo)
+	ie := helpers.BuildIgnoreEvaluator("default", tRC, repo)
 
 	additionsToScan := tRC.FilterAdditions(s.additions)
 
-	detector.DefaultChain(tRC, cc).Test(additionsToScan, tRC, s.results)
+	detector.DefaultChain(tRC, ie).Test(additionsToScan, tRC, s.results)
 	reportsPath, err := report.GenerateReport(s.results, s.reportDirectory)
 	if err != nil {
 		logr.Errorf("error while generating report: %v", err)

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -17,20 +17,20 @@ import (
 // Chain represents a chain of Detectors.
 // It is itself a detector.
 type Chain struct {
-	detectors     []detector.Detector
-	ignoreChecker *helpers.ChecksumCompare
+	detectors       []detector.Detector
+	ignoreEvaluator *helpers.IgnoreEvaluator
 }
 
 // NewChain returns an empty DetectorChain
 // It is itself a detector, but it tests nothing.
-func NewChain(ignoreChecker *helpers.ChecksumCompare) *Chain {
-	result := Chain{[]detector.Detector{}, ignoreChecker}
+func NewChain(ignoreEvaluator *helpers.IgnoreEvaluator) *Chain {
+	result := Chain{[]detector.Detector{}, ignoreEvaluator}
 	return &result
 }
 
 // DefaultChain returns a DetectorChain with pre-configured detectors
-func DefaultChain(tRC *talismanrc.TalismanRC, ignoreChecker *helpers.ChecksumCompare) *Chain {
-	chain := NewChain(ignoreChecker)
+func DefaultChain(tRC *talismanrc.TalismanRC, ignoreEvaluator *helpers.IgnoreEvaluator) *Chain {
+	chain := NewChain(ignoreEvaluator)
 	chain.AddDetector(filename.DefaultFileNameDetector(tRC.Threshold))
 	chain.AddDetector(filecontent.NewFileContentDetector(tRC))
 	chain.AddDetector(pattern.NewPatternDetector(tRC.CustomPatterns))
@@ -52,7 +52,7 @@ func (dc *Chain) Test(additions []gitrepo.Addition, talismanRC *talismanrc.Talis
 	progressBar := utility.GetProgressBar(os.Stdout, "Talisman Scan")
 	progressBar.Start(total)
 	for _, v := range dc.detectors {
-		v.Test(*dc.ignoreChecker, additions, talismanRC, result, func() {
+		v.Test(*dc.ignoreEvaluator, additions, talismanRC, result, func() {
 			progressBar.Increment()
 		})
 	}

--- a/detector/chain_test.go
+++ b/detector/chain_test.go
@@ -21,26 +21,26 @@ func init() {
 
 type FailingDetection struct{}
 
-func (v FailingDetection) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
+func (v FailingDetection) Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	result.Fail("some_file", "filecontent", "FAILED BY DESIGN", []string{}, severity.Low)
 }
 
 type PassingDetection struct{}
 
-func (p PassingDetection) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
+func (p PassingDetection) Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 }
 
 func TestEmptyValidationChainPassesAllValidations(t *testing.T) {
-	cc := helpers.BuildCC("pre-push", nil, gitrepo.RepoLocatedAt("."))
-	v := NewChain(cc)
+	ie := helpers.BuildIgnoreEvaluator("pre-push", nil, gitrepo.RepoLocatedAt("."))
+	v := NewChain(ie)
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	v.Test(nil, &talismanrc.TalismanRC{}, results)
 	assert.False(t, results.HasFailures(), "Empty validation chain is expected to always pass")
 }
 
 func TestValidationChainWithFailingValidationAlwaysFails(t *testing.T) {
-	cc := helpers.BuildCC("pre-push", nil, gitrepo.RepoLocatedAt("."))
-	v := NewChain(cc)
+	ie := helpers.BuildIgnoreEvaluator("pre-push", nil, gitrepo.RepoLocatedAt("."))
+	v := NewChain(ie)
 	v.AddDetector(PassingDetection{})
 	v.AddDetector(FailingDetection{})
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
@@ -54,8 +54,8 @@ func TestDefaultChainShouldCreateChainSpecifiedModeAndPresetDetectors(t *testing
 		Threshold:      severity.Medium,
 		CustomPatterns: []talismanrc.PatternString{"AKIA*"},
 	}
-	cc := helpers.BuildCC("pre-push", talismanRC, gitrepo.RepoLocatedAt("."))
-	v := DefaultChain(talismanRC, cc)
+	ie := helpers.BuildIgnoreEvaluator("pre-push", talismanRC, gitrepo.RepoLocatedAt("."))
+	v := DefaultChain(talismanRC, ie)
 	assert.Equal(t, 3, len(v.detectors))
 
 	defaultFileNameDetector := filename.DefaultFileNameDetector(talismanRC.Threshold)

--- a/detector/chain_test.go
+++ b/detector/chain_test.go
@@ -31,14 +31,16 @@ func (p PassingDetection) Test(comparator helpers.ChecksumCompare, currentAdditi
 }
 
 func TestEmptyValidationChainPassesAllValidations(t *testing.T) {
-	v := NewChain("pre-push")
+	cc := helpers.BuildCC("pre-push", nil, gitrepo.RepoLocatedAt("."))
+	v := NewChain(cc)
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	v.Test(nil, &talismanrc.TalismanRC{}, results)
 	assert.False(t, results.HasFailures(), "Empty validation chain is expected to always pass")
 }
 
 func TestValidationChainWithFailingValidationAlwaysFails(t *testing.T) {
-	v := NewChain("pre-push")
+	cc := helpers.BuildCC("pre-push", nil, gitrepo.RepoLocatedAt("."))
+	v := NewChain(cc)
 	v.AddDetector(PassingDetection{})
 	v.AddDetector(FailingDetection{})
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
@@ -52,8 +54,8 @@ func TestDefaultChainShouldCreateChainSpecifiedModeAndPresetDetectors(t *testing
 		Threshold:      severity.Medium,
 		CustomPatterns: []talismanrc.PatternString{"AKIA*"},
 	}
-	v := DefaultChain(talismanRC, "pre-push")
-	assert.Equal(t, "pre-push", v.mode)
+	cc := helpers.BuildCC("pre-push", talismanRC, gitrepo.RepoLocatedAt("."))
+	v := DefaultChain(talismanRC, cc)
 	assert.Equal(t, 3, len(v.detectors))
 
 	defaultFileNameDetector := filename.DefaultFileNameDetector(talismanRC.Threshold)

--- a/detector/detector/detector.go
+++ b/detector/detector/detector.go
@@ -6,9 +6,9 @@ import (
 	"talisman/talismanrc"
 )
 
-//Detector represents a single kind of test to be performed against a set of Additions
-//Detectors are expected to honor the ignores that are passed in and log them in the results
-//Detectors are expected to signal any errors to the results
+// Detector represents a single kind of test to be performed against a set of Additions
+// Detectors are expected to honor the ignores that are passed in and log them in the results
+// Detectors are expected to signal any errors to the results
 type Detector interface {
-	Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func())
+	Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func())
 }

--- a/detector/filecontent/base64_aggressive_detector_test.go
+++ b/detector/filecontent/base64_aggressive_detector_test.go
@@ -13,7 +13,6 @@ import (
 var _blankTalismanRC = &talismanrc.TalismanRC{}
 var dummyCompletionCallbackFunc = func() {}
 var aggressiveModeFileContentDetector = NewFileContentDetector(_blankTalismanRC).AggressiveMode()
-var defaultCompareChecker = *helpers.BuildCC("default", _blankTalismanRC, gitrepo.RepoLocatedAt("."))
 
 func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 	const awsAccessKeyIDExample string = "AKIAIOSFODNN7EXAMPLE\n"
@@ -23,7 +22,7 @@ func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 
 	aggressiveModeFileContentDetector.
 		Test(
-			defaultCompareChecker,
+			defaultIgnoreEvaluator,
 			additions,
 			_blankTalismanRC,
 			results,
@@ -40,7 +39,7 @@ func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t 
 
 	aggressiveModeFileContentDetector.
 		Test(
-			defaultCompareChecker,
+			defaultIgnoreEvaluator,
 			additions,
 			_blankTalismanRC,
 			results,
@@ -62,7 +61,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *
 
 	aggressiveModeFileContentDetector.
 		Test(
-			defaultCompareChecker,
+			defaultIgnoreEvaluator,
 			additions,
 			_blankTalismanRC,
 			results,

--- a/detector/filecontent/base64_aggressive_detector_test.go
+++ b/detector/filecontent/base64_aggressive_detector_test.go
@@ -13,6 +13,7 @@ import (
 var _blankTalismanRC = &talismanrc.TalismanRC{}
 var dummyCompletionCallbackFunc = func() {}
 var aggressiveModeFileContentDetector = NewFileContentDetector(_blankTalismanRC).AggressiveMode()
+var defaultCompareChecker = *helpers.BuildCC("default", _blankTalismanRC, gitrepo.RepoLocatedAt("."))
 
 func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 	const awsAccessKeyIDExample string = "AKIAIOSFODNN7EXAMPLE\n"
@@ -22,7 +23,7 @@ func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 
 	aggressiveModeFileContentDetector.
 		Test(
-			helpers.NewChecksumCompare(nil, _blankTalismanRC),
+			defaultCompareChecker,
 			additions,
 			_blankTalismanRC,
 			results,
@@ -39,7 +40,7 @@ func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t 
 
 	aggressiveModeFileContentDetector.
 		Test(
-			helpers.NewChecksumCompare(nil, _blankTalismanRC),
+			defaultCompareChecker,
 			additions,
 			_blankTalismanRC,
 			results,
@@ -61,7 +62,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *
 
 	aggressiveModeFileContentDetector.
 		Test(
-			helpers.NewChecksumCompare(nil, _blankTalismanRC),
+			defaultCompareChecker,
 			additions,
 			_blankTalismanRC,
 			results,

--- a/detector/filecontent/filecontent_detector.go
+++ b/detector/filecontent/filecontent_detector.go
@@ -109,7 +109,7 @@ func (fc *FileContentDetector) Test(comparator helpers.ChecksumCompare, currentA
 		go func(addition gitrepo.Addition) {
 			defer waitGroup.Done()
 			defer additionCompletionCallback()
-			if talismanRC.Deny(addition, "filecontent") || comparator.IsScanNotRequired(addition) {
+			if comparator.ShouldIgnore(addition, "filecontent") {
 				ignoredFilePaths <- addition.Path
 				return
 			}

--- a/detector/filecontent/filecontent_detector.go
+++ b/detector/filecontent/filecontent_detector.go
@@ -76,7 +76,7 @@ type content struct {
 	severity    severity.Severity
 }
 
-func (fc *FileContentDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, talismanRC *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
+func (fc *FileContentDetector) Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, talismanRC *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	contentTypes := []struct {
 		contentType
 		fn

--- a/detector/filename/filename_detector.go
+++ b/detector/filename/filename_detector.go
@@ -83,7 +83,7 @@ func NewFileNameDetector(patternsWithSeverity []*severity.PatternSeverity, thres
 }
 
 // Test tests the fileNames of the Additions to ensure that they don't look suspicious
-func (fd FileNameDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
+func (fd FileNameDetector) Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	for _, addition := range currentAdditions {
 		if comparator.ShouldIgnore(addition, "filename") {
 			log.WithFields(log.Fields{

--- a/detector/filename/filename_detector.go
+++ b/detector/filename/filename_detector.go
@@ -65,27 +65,27 @@ var (
 	}
 )
 
-//FileNameDetector represents tests performed against the fileName of the Additions.
-//The Paths of the supplied Additions are tested against the configured patterns and if any of them match, it is logged as a failure during the run
+// FileNameDetector represents tests performed against the fileName of the Additions.
+// The Paths of the supplied Additions are tested against the configured patterns and if any of them match, it is logged as a failure during the run
 type FileNameDetector struct {
 	flagPatterns []*severity.PatternSeverity
 	threshold    severity.Severity
 }
 
-//DefaultFileNameDetector returns a FileNameDetector that tests Additions against the pre-configured patterns
+// DefaultFileNameDetector returns a FileNameDetector that tests Additions against the pre-configured patterns
 func DefaultFileNameDetector(threshold severity.Severity) detector.Detector {
 	return NewFileNameDetector(filenamePatterns, threshold)
 }
 
-//NewFileNameDetector returns a FileNameDetector that tests Additions against the supplied patterns
+// NewFileNameDetector returns a FileNameDetector that tests Additions against the supplied patterns
 func NewFileNameDetector(patternsWithSeverity []*severity.PatternSeverity, threshold severity.Severity) detector.Detector {
 	return FileNameDetector{patternsWithSeverity, threshold}
 }
 
-//Test tests the fileNames of the Additions to ensure that they don't look suspicious
+// Test tests the fileNames of the Additions to ensure that they don't look suspicious
 func (fd FileNameDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	for _, addition := range currentAdditions {
-		if ignoreConfig.Deny(addition, "filename") || comparator.IsScanNotRequired(addition) {
+		if comparator.ShouldIgnore(addition, "filename") {
 			log.WithFields(log.Fields{
 				"filePath": addition.Path,
 			}).Info("Ignoring addition as it was specified to be ignored.")

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultChecksumCompareUtility = *helpers.BuildCC("default", talismanRC, gitrepo.RepoLocatedAt("."))
+var defaultIgnoreEvaluator = *helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
 
-func checksumCompareWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.ChecksumCompare {
-	return helpers.BuildCC("default", tRC, gitrepo.RepoLocatedAt("."))
+func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.IgnoreEvaluator {
+	return helpers.BuildIgnoreEvaluator("default", tRC, gitrepo.RepoLocatedAt("."))
 }
 
 func TestShouldFlagPotentialSSHPrivateKeys(t *testing.T) {
@@ -148,7 +148,7 @@ func TestShouldIgnoreIfErrorIsBelowThreshold(t *testing.T) {
 	fileName := ".bash_aliases"
 
 	DefaultFileNameDetector(severity.High).
-		Test(defaultChecksumCompareUtility, additionsNamed(fileName), talismanRC, results, func() {})
+		Test(defaultIgnoreEvaluator, additionsNamed(fileName), talismanRC, results, func() {})
 
 	assert.False(t, results.HasFailures(), "Expected file %s to not fail", fileName)
 	assert.True(t, results.HasWarnings(), "Expected file %s to having warnings", fileName)
@@ -177,7 +177,7 @@ func shouldNotFailWithDefaultDetectorAndIgnores(fileName, ignore string, thresho
 	talismanRC.IgnoreConfigs = []talismanrc.IgnoreConfig{fileIgnoreConfig}
 
 	DefaultFileNameDetector(threshold).
-		Test(*checksumCompareWithTalismanRC(talismanRC), additionsNamed(fileName), talismanRC, results, func() {})
+		Test(*ignoreEvaluatorWithTalismanRC(talismanRC), additionsNamed(fileName), talismanRC, results, func() {})
 
 	assert.True(t,
 		results.Successful(),
@@ -189,7 +189,7 @@ func shouldFailWithSpecificPattern(fileName, pattern string, threshold severity.
 	pt := []*severity.PatternSeverity{{Pattern: regexp.MustCompile(pattern), Severity: severity.Low}}
 
 	NewFileNameDetector(pt, threshold).
-		Test(defaultChecksumCompareUtility, additionsNamed(fileName), talismanRC, results, func() {})
+		Test(defaultIgnoreEvaluator, additionsNamed(fileName), talismanRC, results, func() {})
 
 	assert.True(t,
 		results.HasFailures(),
@@ -199,7 +199,7 @@ func shouldFailWithSpecificPattern(fileName, pattern string, threshold severity.
 func shouldFailWithDefaultDetector(fileName, pattern string, severity severity.Severity, t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	DefaultFileNameDetector(severity).
-		Test(defaultChecksumCompareUtility, additionsNamed(fileName), talismanRC, results, func() {})
+		Test(defaultIgnoreEvaluator, additionsNamed(fileName), talismanRC, results, func() {})
 	assert.True(t,
 		results.HasFailures(),
 		"Expected file %s to fail the check against default detector. Missing pattern %s?", fileName, pattern)

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultChecksumCompareUtility = helpers.NewChecksumCompare(nil, talismanRC)
+var defaultChecksumCompareUtility = *helpers.BuildCC("default", talismanRC, gitrepo.RepoLocatedAt("."))
 
 func TestShouldFlagPotentialSSHPrivateKeys(t *testing.T) {
 	shouldFail("id_rsa", "^.+_rsa$", severity.Low, t)

--- a/detector/filesize/filesize_detector.go
+++ b/detector/filesize/filesize_detector.go
@@ -22,7 +22,7 @@ func NewFileSizeDetector(size int) detector.Detector {
 func (fd FileSizeDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	largeFileSizeSeverity := severity.SeverityConfiguration["LargeFileSize"]
 	for _, addition := range currentAdditions {
-		if ignoreConfig.Deny(addition, "filesize") || comparator.IsScanNotRequired(addition) {
+		if comparator.ShouldIgnore(addition, "filesize") {
 			log.WithFields(log.Fields{
 				"filePath": addition.Path,
 			}).Info("Ignoring addition as it was specified to be ignored.")

--- a/detector/filesize/filesize_detector.go
+++ b/detector/filesize/filesize_detector.go
@@ -19,7 +19,7 @@ func NewFileSizeDetector(size int) detector.Detector {
 	return FileSizeDetector{size}
 }
 
-func (fd FileSizeDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
+func (fd FileSizeDetector) Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	largeFileSizeSeverity := severity.SeverityConfiguration["LargeFileSize"]
 	for _, addition := range currentAdditions {
 		if comparator.ShouldIgnore(addition, "filesize") {

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -12,17 +12,17 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultChecksumCompareUtility = *helpers.BuildCC("default", talismanRC, gitrepo.RepoLocatedAt("."))
+var defaultIgnoreEvaluator = *helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
 
-func checksumCompareWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.ChecksumCompare {
-	return helpers.BuildCC("default", tRC, gitrepo.RepoLocatedAt("."))
+func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.IgnoreEvaluator {
+	return helpers.BuildIgnoreEvaluator("default", tRC, gitrepo.RepoLocatedAt("."))
 }
 
 func TestShouldFlagLargeFiles(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("more than one byte")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(defaultIgnoreEvaluator, additions, talismanRC, results, func() {})
 	assert.True(t, results.HasFailures(), "Expected file to fail the check against file size detector.")
 }
 
@@ -31,7 +31,7 @@ func TestShouldNotFlagLargeFilesIfThresholdIsBelowSeverity(t *testing.T) {
 	content := []byte("more than one byte")
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRCWithThreshold, results, func() {})
+	NewFileSizeDetector(2).Test(defaultIgnoreEvaluator, additions, talismanRCWithThreshold, results, func() {})
 	assert.False(t, results.HasFailures(), "Expected file to not fail the check against file size detector.")
 	assert.True(t, results.HasWarnings(), "Expected file to have warnings against file size detector.")
 }
@@ -40,7 +40,7 @@ func TestShouldNotFlagSmallFiles(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("m")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(defaultIgnoreEvaluator, additions, talismanRC, results, func() {})
 	assert.False(t, results.HasFailures(), "Expected file to not fail the check against file size detector.")
 }
 
@@ -58,6 +58,6 @@ func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {
 	}
 
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	NewFileSizeDetector(2).Test(*checksumCompareWithTalismanRC(talismanRC), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(*ignoreEvaluatorWithTalismanRC(talismanRC), additions, talismanRC, results, func() {})
 	assert.True(t, results.Successful(), "expected file %s to be ignored by file size detector", filename)
 }

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
+var defaultChecksumCompareUtility = *helpers.BuildCC("default", talismanRC, gitrepo.RepoLocatedAt("."))
 
 func TestShouldFlagLargeFiles(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("more than one byte")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, talismanRC), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRC, results, func() {})
 	assert.True(t, results.HasFailures(), "Expected file to fail the check against file size detector.")
 }
 
@@ -26,7 +27,7 @@ func TestShouldNotFlagLargeFilesIfThresholdIsBelowSeverity(t *testing.T) {
 	content := []byte("more than one byte")
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, talismanRCWithThreshold), additions, talismanRCWithThreshold, results, func() {})
+	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRCWithThreshold, results, func() {})
 	assert.False(t, results.HasFailures(), "Expected file to not fail the check against file size detector.")
 	assert.True(t, results.HasWarnings(), "Expected file to have warnings against file size detector.")
 }
@@ -35,7 +36,7 @@ func TestShouldNotFlagSmallFiles(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("m")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, talismanRC), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRC, results, func() {})
 	assert.False(t, results.HasFailures(), "Expected file to not fail the check against file size detector.")
 }
 
@@ -53,6 +54,6 @@ func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {
 	talismanRC.IgnoreConfigs[0] = fileIgnoreConfig
 
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	NewFileSizeDetector(2).Test(helpers.NewChecksumCompare(nil, talismanRC), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(defaultChecksumCompareUtility, additions, talismanRC, results, func() {})
 	assert.True(t, results.Successful(), "expected file %s to be ignored by file size detector", filename)
 }

--- a/detector/helpers/checksum_compare.go
+++ b/detector/helpers/checksum_compare.go
@@ -21,8 +21,8 @@ func BuildCC(hasherMode string, talismanRC *talismanrc.TalismanRC, repo gitrepo.
 	return &ChecksumCompare{calculator: calculator, talismanRC: talismanRC}
 }
 
-// IsScanNotRequired returns true if an Addition's checksum matches one ignored by the .talismanrc file
-func (cc *ChecksumCompare) IsScanNotRequired(addition gitrepo.Addition) bool {
+// isScanNotRequired returns true if an Addition's checksum matches one ignored by the .talismanrc file
+func (cc *ChecksumCompare) isScanNotRequired(addition gitrepo.Addition) bool {
 	for _, ignore := range cc.talismanRC.IgnoreConfigs {
 		if addition.Matches(ignore.GetFileName()) {
 			currentCollectiveChecksum := cc.calculator.CalculateCollectiveChecksumForPattern(ignore.GetFileName())
@@ -32,6 +32,7 @@ func (cc *ChecksumCompare) IsScanNotRequired(addition gitrepo.Addition) bool {
 	return false
 }
 
+// ShouldIgnore returns true if the talismanRC indicates that a Detector should ignore an Addition
 func (cc *ChecksumCompare) ShouldIgnore(addition gitrepo.Addition, detectorType string) bool {
-	return cc.talismanRC.Deny(addition, detectorType) || cc.IsScanNotRequired(addition)
+	return cc.talismanRC.Deny(addition, detectorType) || cc.isScanNotRequired(addition)
 }

--- a/detector/helpers/checksum_compare_test.go
+++ b/detector/helpers/checksum_compare_test.go
@@ -22,7 +22,7 @@ func TestChecksumCompare_IsScanNotRequired(t *testing.T) {
 		ignoreConfig := &talismanrc.TalismanRC{
 			IgnoreConfigs: []talismanrc.IgnoreConfig{},
 		}
-		cc := NewChecksumCompare(nil, ignoreConfig)
+		cc := ChecksumCompare{nil, ignoreConfig}
 		addition := gitrepo.Addition{Path: "some.txt"}
 
 		required := cc.IsScanNotRequired(addition)
@@ -42,8 +42,8 @@ func TestChecksumCompare_IsScanNotRequired(t *testing.T) {
 				},
 			},
 		}
+		cc := ChecksumCompare{calculator: checksumCalculator, talismanRC: &ignoreConfig}
 		addition := gitrepo.Addition{Name: "some.txt", Path: "some.txt"}
-		cc := NewChecksumCompare(checksumCalculator, &ignoreConfig)
 		checksumCalculator.EXPECT().CalculateCollectiveChecksumForPattern("some.txt").Return("sha1")
 
 		required := cc.IsScanNotRequired(addition)

--- a/detector/helpers/ignore_evaluator_test.go
+++ b/detector/helpers/ignore_evaluator_test.go
@@ -16,16 +16,16 @@ import (
 func init() {
 	logr.SetOutput(io.Discard)
 }
-func TestChecksumCompare_IsScanNotRequired(t *testing.T) {
+func TestIsScanNotRequired(t *testing.T) {
 
 	t.Run("should return false if talismanrc is empty", func(t *testing.T) {
 		ignoreConfig := &talismanrc.TalismanRC{
 			IgnoreConfigs: []talismanrc.IgnoreConfig{},
 		}
-		cc := ChecksumCompare{nil, ignoreConfig}
+		ie := IgnoreEvaluator{nil, ignoreConfig}
 		addition := gitrepo.Addition{Path: "some.txt"}
 
-		required := cc.isScanNotRequired(addition)
+		required := ie.isScanNotRequired(addition)
 
 		assert.False(t, required)
 	})
@@ -42,11 +42,11 @@ func TestChecksumCompare_IsScanNotRequired(t *testing.T) {
 				},
 			},
 		}
-		cc := ChecksumCompare{calculator: checksumCalculator, talismanRC: &ignoreConfig}
+		ie := IgnoreEvaluator{calculator: checksumCalculator, talismanRC: &ignoreConfig}
 		addition := gitrepo.Addition{Name: "some.txt", Path: "some.txt"}
 		checksumCalculator.EXPECT().CalculateCollectiveChecksumForPattern("some.txt").Return("sha1")
 
-		required := cc.isScanNotRequired(addition)
+		required := ie.isScanNotRequired(addition)
 
 		assert.True(t, required)
 	})
@@ -79,21 +79,21 @@ func TestDeterminingFilesToIgnore(t *testing.T) {
 			},
 		},
 	}
-	cc := ChecksumCompare{&sillyChecksumCalculator{}, &tRC}
+	ie := IgnoreEvaluator{&sillyChecksumCalculator{}, &tRC}
 
 	t.Run("Should ignore file based on checksum", func(t *testing.T) {
-		assert.True(t, cc.ShouldIgnore(gitrepo.Addition{Path: "some.txt"}, ""))
+		assert.True(t, ie.ShouldIgnore(gitrepo.Addition{Path: "some.txt"}, ""))
 	})
 
 	t.Run("Should not ignore file if checksum doesn't match", func(t *testing.T) {
-		assert.False(t, cc.ShouldIgnore(gitrepo.Addition{Path: "other.txt"}, ""))
+		assert.False(t, ie.ShouldIgnore(gitrepo.Addition{Path: "other.txt"}, ""))
 	})
 
 	t.Run("Should ignore if detector is disabled for file", func(t *testing.T) {
-		assert.True(t, cc.ShouldIgnore(gitrepo.Addition{Path: "ignore-contents"}, "filecontent"))
+		assert.True(t, ie.ShouldIgnore(gitrepo.Addition{Path: "ignore-contents"}, "filecontent"))
 	})
 
 	t.Run("Should not ignore if a different detector is disabled for file", func(t *testing.T) {
-		assert.False(t, cc.ShouldIgnore(gitrepo.Addition{Path: "ignore-contents"}, "filename"))
+		assert.False(t, ie.ShouldIgnore(gitrepo.Addition{Path: "ignore-contents"}, "filename"))
 	})
 }

--- a/detector/pattern/pattern_detector.go
+++ b/detector/pattern/pattern_detector.go
@@ -37,7 +37,7 @@ type match struct {
 }
 
 // Test tests the contents of the Additions to ensure that they don't look suspicious
-func (detector PatternDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
+func (detector PatternDetector) Test(comparator helpers.IgnoreEvaluator, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	matches := make(chan match, 512)
 	ignoredFilePaths := make(chan gitrepo.FilePath, 512)
 	waitGroup := &sync.WaitGroup{}

--- a/detector/pattern/pattern_detector.go
+++ b/detector/pattern/pattern_detector.go
@@ -36,7 +36,7 @@ type match struct {
 	detections []DetectionsWithSeverity
 }
 
-//Test tests the contents of the Additions to ensure that they don't look suspicious
+// Test tests the contents of the Additions to ensure that they don't look suspicious
 func (detector PatternDetector) Test(comparator helpers.ChecksumCompare, currentAdditions []gitrepo.Addition, ignoreConfig *talismanrc.TalismanRC, result *helpers.DetectionResults, additionCompletionCallback func()) {
 	matches := make(chan match, 512)
 	ignoredFilePaths := make(chan gitrepo.FilePath, 512)
@@ -46,7 +46,7 @@ func (detector PatternDetector) Test(comparator helpers.ChecksumCompare, current
 		go func(addition gitrepo.Addition) {
 			defer waitGroup.Done()
 			defer additionCompletionCallback()
-			if ignoreConfig.Deny(addition, "filecontent") || comparator.IsScanNotRequired(addition) {
+			if comparator.ShouldIgnore(addition, "filecontent") {
 				ignoredFilePaths <- addition.Path
 				return
 			}
@@ -106,7 +106,7 @@ func (detector PatternDetector) processMatch(match match, result *helpers.Detect
 	}
 }
 
-//NewPatternDetector returns a PatternDetector that tests Additions against the pre-configured patterns
+// NewPatternDetector returns a PatternDetector that tests Additions against the pre-configured patterns
 func NewPatternDetector(custom []talismanrc.PatternString) *PatternDetector {
 	matcher := NewPatternMatcher(detectorPatterns)
 	for _, pattern := range custom {

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -20,6 +20,10 @@ var (
 	customPatterns []talismanrc.PatternString
 )
 
+func checksumCompareWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.ChecksumCompare {
+	return helpers.BuildCC("default", tRC, gitrepo.RepoLocatedAt("."))
+}
+
 func TestShouldDetectPasswordPatterns(t *testing.T) {
 	filename := "secret.txt"
 	values := [7]string{"password", "secret", "key", "pwd", "pass", "pword", "passphrase"}
@@ -61,7 +65,7 @@ func TestShouldDetectPasswordPatterns(t *testing.T) {
 	shouldFailDetectionOfSecretPattern(filename, []byte(`random=12345678)`), t)
 }
 
-func TestShouldIgnorePasswordPatterns(t *testing.T) {
+func TestShouldIgnorePasswordPatternsIfChecksumMatches(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	content := []byte("\"password\" : UnsafePassword")
 	filename := "secret.txt"
@@ -73,9 +77,9 @@ func TestShouldIgnorePasswordPatterns(t *testing.T) {
 		AllowedPatterns: []string{}}
 	ignores := &talismanrc.TalismanRC{IgnoreConfigs: []talismanrc.IgnoreConfig{fileIgnoreConfig}}
 
-	NewPatternDetector(customPatterns).Test(defaultChecksumCompare, additions, ignores, results, dummyCallback)
+	NewPatternDetector(customPatterns).Test(*checksumCompareWithTalismanRC(ignores), additions, ignores, results, dummyCallback)
 
-	assert.True(t, results.Successful(), "Expected file %s to be ignored by pattern", filename)
+	assert.True(t, results.Successful(), "Expected file %s to be ignored because checksum matches", filename)
 }
 
 func TestShouldIgnoreAllowedPattern(t *testing.T) {

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultChecksumCompare = helpers.NewChecksumCompare(nil, talismanRC)
+var defaultChecksumCompare = *helpers.BuildCC("default", talismanRC, gitrepo.RepoLocatedAt("."))
 var dummyCallback = func() {}
 
 var (
@@ -103,7 +103,7 @@ func TestShouldOnlyWarnSecretPatternIfBelowThreshold(t *testing.T) {
 	filename := "secret.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
-	checksumCompare := helpers.NewChecksumCompare(nil, talismanRCWithThreshold)
+	checksumCompare := *helpers.BuildCC("default", talismanRCWithThreshold, gitrepo.RepoLocatedAt("."))
 
 	NewPatternDetector(customPatterns).Test(checksumCompare, additions, talismanRCWithThreshold, results, dummyCallback)
 


### PR DESCRIPTION
This elevates and replaces the current ChecksumCompare struct and makes it more capable of making all decisions around what file additions should be ignored by the scan and when.