### PR TITLE
Load talismanrc the same way for all modes

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -22,7 +22,7 @@ type runner struct {
 func NewRunner(additions []gitrepo.Addition, mode string) *runner {
 	return &runner{
 		additions: additions,
-		results:   helpers.NewDetectionResults(talismanrc.HookMode),
+		results:   helpers.NewDetectionResults(),
 		mode:      mode,
 	}
 }

--- a/cmd/scanner_cmd.go
+++ b/cmd/scanner_cmd.go
@@ -62,7 +62,7 @@ func NewScannerCmd(ignoreHistory bool, tRC *talismanrc.TalismanRC, reportDirecto
 	}
 	return &ScannerCmd{
 		additions:       additions,
-		results:         helpers.NewDetectionResults(talismanrc.ScanMode),
+		results:         helpers.NewDetectionResults(),
 		reportDirectory: reportDirectory,
 		ignoreEvaluator: ignoreEvaluator,
 		tRC:             tRC,

--- a/cmd/talisman.go
+++ b/cmd/talisman.go
@@ -149,39 +149,39 @@ func run(promptContext prompt.PromptContext) (returnCode int) {
 		return NewChecksumCmd(strings.Fields(options.Checksum)).Run()
 	} else if options.Scan {
 		log.Infof("Running scanner")
-		talismanrcForScan, err := talismanrc.ForScan(options.IgnoreHistory)
+		talismanrc, err := talismanrc.Load()
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewScannerCmd(options.IgnoreHistory, talismanrcForScan, options.ReportDirectory).Run()
+		return NewScannerCmd(options.IgnoreHistory, talismanrc, options.ReportDirectory).Run()
 	} else if options.ScanWithHtml {
 		log.Infof("Running scanner with html report")
-		talismanrcForScan, err := talismanrc.ForScan(options.IgnoreHistory)
+		talismanrc, err := talismanrc.Load()
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewScannerCmd(options.IgnoreHistory, talismanrcForScan, "talisman_html_report").Run()
+		return NewScannerCmd(options.IgnoreHistory, talismanrc, "talisman_html_report").Run()
 	} else if options.Pattern != "" {
 		log.Infof("Running scan for %s", options.Pattern)
-		talismanrcForScan, err := talismanrc.For(talismanrc.HookMode)
+		talismanrc, err := talismanrc.Load()
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewPatternCmd(options.Pattern).Run(talismanrcForScan, promptContext)
+		return NewPatternCmd(options.Pattern).Run(talismanrc, promptContext)
 	} else if options.GitHook == PreCommit {
 		log.Infof("Running %s hook", options.GitHook)
-		talismanrcForScan, err := talismanrc.For(talismanrc.HookMode)
+		talismanrc, err := talismanrc.Load()
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewPreCommitHook().Run(talismanrcForScan, promptContext)
+		return NewPreCommitHook().Run(talismanrc, promptContext)
 	} else {
 		log.Infof("Running %s hook", options.GitHook)
-		talismanrcForScan, err := talismanrc.For(talismanrc.HookMode)
+		talismanrc, err := talismanrc.Load()
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewPrePushHook(talismanInput).Run(talismanrcForScan, promptContext)
+		return NewPrePushHook(talismanInput).Run(talismanrc, promptContext)
 	}
 }
 

--- a/cmd/talisman.go
+++ b/cmd/talisman.go
@@ -153,14 +153,14 @@ func run(promptContext prompt.PromptContext) (returnCode int) {
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewScannerCmd(options.IgnoreHistory, options.ReportDirectory).Run(talismanrcForScan)
+		return NewScannerCmd(options.IgnoreHistory, talismanrcForScan, options.ReportDirectory).Run()
 	} else if options.ScanWithHtml {
 		log.Infof("Running scanner with html report")
 		talismanrcForScan, err := talismanrc.ForScan(options.IgnoreHistory)
 		if err != nil {
 			return EXIT_FAILURE
 		}
-		return NewScannerCmd(options.IgnoreHistory, "talisman_html_report").Run(talismanrcForScan)
+		return NewScannerCmd(options.IgnoreHistory, talismanrcForScan, "talisman_html_report").Run()
 	} else if options.Pattern != "" {
 		log.Infof("Running scan for %s", options.Pattern)
 		talismanrcForScan, err := talismanrc.For(talismanrc.HookMode)

--- a/detector/chain.go
+++ b/detector/chain.go
@@ -18,18 +18,18 @@ import (
 // It is itself a detector.
 type Chain struct {
 	detectors       []detector.Detector
-	ignoreEvaluator *helpers.IgnoreEvaluator
+	ignoreEvaluator helpers.IgnoreEvaluator
 }
 
 // NewChain returns an empty DetectorChain
 // It is itself a detector, but it tests nothing.
-func NewChain(ignoreEvaluator *helpers.IgnoreEvaluator) *Chain {
+func NewChain(ignoreEvaluator helpers.IgnoreEvaluator) *Chain {
 	result := Chain{[]detector.Detector{}, ignoreEvaluator}
 	return &result
 }
 
 // DefaultChain returns a DetectorChain with pre-configured detectors
-func DefaultChain(tRC *talismanrc.TalismanRC, ignoreEvaluator *helpers.IgnoreEvaluator) *Chain {
+func DefaultChain(tRC *talismanrc.TalismanRC, ignoreEvaluator helpers.IgnoreEvaluator) *Chain {
 	chain := NewChain(ignoreEvaluator)
 	chain.AddDetector(filename.DefaultFileNameDetector(tRC.Threshold))
 	chain.AddDetector(filecontent.NewFileContentDetector(tRC))
@@ -52,7 +52,7 @@ func (dc *Chain) Test(additions []gitrepo.Addition, talismanRC *talismanrc.Talis
 	progressBar := utility.GetProgressBar(os.Stdout, "Talisman Scan")
 	progressBar.Start(total)
 	for _, v := range dc.detectors {
-		v.Test(*dc.ignoreEvaluator, additions, talismanRC, result, func() {
+		v.Test(dc.ignoreEvaluator, additions, talismanRC, result, func() {
 			progressBar.Increment()
 		})
 	}

--- a/detector/chain_test.go
+++ b/detector/chain_test.go
@@ -33,7 +33,7 @@ func (p PassingDetection) Test(comparator helpers.IgnoreEvaluator, currentAdditi
 func TestEmptyValidationChainPassesAllValidations(t *testing.T) {
 	ie := helpers.BuildIgnoreEvaluator("pre-push", nil, gitrepo.RepoLocatedAt("."))
 	v := NewChain(ie)
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	v.Test(nil, &talismanrc.TalismanRC{}, results)
 	assert.False(t, results.HasFailures(), "Empty validation chain is expected to always pass")
 }
@@ -43,7 +43,7 @@ func TestValidationChainWithFailingValidationAlwaysFails(t *testing.T) {
 	v := NewChain(ie)
 	v.AddDetector(PassingDetection{})
 	v.AddDetector(FailingDetection{})
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	v.Test(nil, &talismanrc.TalismanRC{}, results)
 
 	assert.False(t, results.Successful(), "Expected validation chain with a failure to fail.")

--- a/detector/filecontent/base64_aggressive_detector_test.go
+++ b/detector/filecontent/base64_aggressive_detector_test.go
@@ -16,7 +16,7 @@ var aggressiveModeFileContentDetector = NewFileContentDetector(_blankTalismanRC)
 
 func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 	const awsAccessKeyIDExample string = "AKIAIOSFODNN7EXAMPLE\n"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	filename := "filename"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(awsAccessKeyIDExample))}
 
@@ -33,7 +33,7 @@ func TestShouldFlagPotentialAWSAccessKeysInAggressiveMode(t *testing.T) {
 
 func TestShouldFlagPotentialAWSAccessKeysAtPropertyDefinitionInAggressiveMode(t *testing.T) {
 	const awsAccessKeyIDExample string = "accessKey=AKIAIOSFODNN7EXAMPLE"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	filename := "filename"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(awsAccessKeyIDExample))}
 
@@ -55,7 +55,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCodeEvenInAggressiveMode(t *
 		"		System.out.println(\"Hello, World\");\r\n    " +
 		"	}\r\n\r\n" +
 		"}"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	filename := "filename"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(awsAccessKeyIDExample))}
 

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var emptyTalismanRC = &talismanrc.TalismanRC{IgnoreConfigs: []talismanrc.IgnoreConfig{}}
-var defaultIgnoreEvaluator = *helpers.BuildIgnoreEvaluator("default", emptyTalismanRC, gitrepo.RepoLocatedAt("."))
+var defaultIgnoreEvaluator = helpers.BuildIgnoreEvaluator("default", emptyTalismanRC, gitrepo.RepoLocatedAt("."))
 var dummyCallback = func() {}
 var filename = "filename"
 
@@ -180,7 +180,7 @@ func TestShouldNotFlagPotentialCreditCardNumberIfAboveThreshold(t *testing.T) {
 	results := helpers.NewDetectionResults(talismanrc.HookMode)
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(creditCardNumber))}
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
-	ignoreEvaluatorWithThreshold := *helpers.BuildIgnoreEvaluator("default", talismanRCWithThreshold, gitrepo.RepoLocatedAt("."))
+	ignoreEvaluatorWithThreshold := helpers.BuildIgnoreEvaluator("default", talismanRCWithThreshold, gitrepo.RepoLocatedAt("."))
 
 	NewFileContentDetector(emptyTalismanRC).
 		Test(ignoreEvaluatorWithThreshold, additions, talismanRCWithThreshold, results, dummyCallback)

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -19,7 +19,7 @@ var dummyCallback = func() {}
 var filename = "filename"
 
 func TestShouldNotFlagSafeText(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte("prettySafe"))}
 
 	NewFileContentDetector(emptyTalismanRC).
@@ -28,7 +28,7 @@ func TestShouldNotFlagSafeText(t *testing.T) {
 }
 
 func TestShouldIgnoreFileIfNeeded(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte("prettySafe"))}
 	talismanRCIWithFilenameIgnore := &talismanrc.TalismanRC{
 		IgnoreConfigs: []talismanrc.IgnoreConfig{
@@ -47,7 +47,7 @@ func TestShouldNotFlag4CharSafeText(t *testing.T) {
 		input is actually a b64 encoded value. In other words, abcd will match, but it is not necessarily represent
 		 the encoded value of i· rather just a plain abcd input see
 	stackoverflow.com/questions/8571501/how-to-check-whether-the-string-is-base64-encoded-or-not#comment23919648_8571649*/
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte("abcd"))}
 
 	NewFileContentDetector(emptyTalismanRC).
@@ -57,7 +57,7 @@ func TestShouldNotFlag4CharSafeText(t *testing.T) {
 
 func TestShouldNotFlagLowEntropyBase64Text(t *testing.T) {
 	const lowEntropyString string = "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWEK"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte(lowEntropyString)
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 
@@ -68,7 +68,7 @@ func TestShouldNotFlagLowEntropyBase64Text(t *testing.T) {
 
 func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
 	const awsSecretAccessKey string = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(awsSecretAccessKey))}
 	filePath := additions[0].Path
 
@@ -84,7 +84,7 @@ func TestShouldFlagPotentialAWSSecretKeys(t *testing.T) {
 
 func TestShouldFlagPotentialSecretWithoutTrimmingWhenLengthLessThan50Characters(t *testing.T) {
 	const secret string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9asdfa"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(secret))}
 	filePath := additions[0].Path
 
@@ -100,7 +100,7 @@ func TestShouldFlagPotentialSecretWithoutTrimmingWhenLengthLessThan50Characters(
 func TestShouldFlagPotentialJWT(t *testing.T) {
 	const jwt string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY290Y2guaW8iLCJleHAiOjEzMDA4MTkzODAsIm5hbWUi" +
 		"OiJDaHJpcyBTZXZpbGxlamEiLCJhZG1pbiI6dHJ1ZX0.03f329983b86f7d9a9f5fef85305880101d5e302afafa20154d094b229f757"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte(jwt)
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 	filePath := additions[0].Path
@@ -123,7 +123,7 @@ func TestShouldFlagPotentialSecretsWithinJavaCode(t *testing.T) {
 		"		System.out.println(\"Hello, World\");\r\n    " +
 		"		}\r\n\r\n" +
 		"}"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte(dangerousJavaCode)
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 	filePath := additions[0].Path
@@ -144,7 +144,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCode(t *testing.T) {
 		"   	System.out.println(\"Hello, World\");\r\n    " +
 		"	}\r\n\r\n" +
 		"}"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(safeJavaCode))}
 
 	NewFileContentDetector(emptyTalismanRC).
@@ -154,7 +154,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeJavaCode(t *testing.T) {
 
 func TestShouldNotFlagPotentialSecretsWithinSafeLongMethodName(t *testing.T) {
 	safeLongMethodName := "TestBase64DetectorShouldNotDetectLongMethodNamesEvenWithRidiculousHighEntropyWordsMightExist"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(safeLongMethodName))}
 
 	NewFileContentDetector(emptyTalismanRC).
@@ -164,7 +164,7 @@ func TestShouldNotFlagPotentialSecretsWithinSafeLongMethodName(t *testing.T) {
 
 func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
 	const hex string = "68656C6C6F20776F726C6421"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(hex))}
 	filePath := additions[0].Path
 
@@ -177,7 +177,7 @@ func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
 
 func TestShouldNotFlagPotentialCreditCardNumberIfAboveThreshold(t *testing.T) {
 	const creditCardNumber string = "340000000000009"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(creditCardNumber))}
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	ignoreEvaluatorWithThreshold := helpers.BuildIgnoreEvaluator("default", talismanRCWithThreshold, gitrepo.RepoLocatedAt("."))
@@ -192,7 +192,7 @@ func TestShouldNotFlagPotentialSecretsIfIgnored(t *testing.T) {
 	const hex string = "68656C6C6F20776F726C6421"
 	talismanRCWithIgnores := &talismanrc.TalismanRC{
 		AllowedPatterns: []*regexp.Regexp{regexp.MustCompile("[0-9a-fA-F]*")}}
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(hex))}
 
 	NewFileContentDetector(emptyTalismanRC).
@@ -203,7 +203,7 @@ func TestShouldNotFlagPotentialSecretsIfIgnored(t *testing.T) {
 
 func TestResultsShouldNotFlagCreditCardNumberIfSpecifiedInFileIgnores(t *testing.T) {
 	const creditCardNumber string = "340000000000009"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
 		FileName: filename, Checksum: "",
 		AllowedPatterns: []string{creditCardNumber},
@@ -224,7 +224,7 @@ func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
 	const hex string = "68656C6C6F20776F726C6421"
 	const base64 string = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	const hexAndBase64 = hex + "\n" + base64
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(hexAndBase64))}
 	filePath := additions[0].Path
 
@@ -240,7 +240,7 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 	const hex string = "68656C6C6F20776F726C6421"
 	const base64 string = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	const hexAndBase64 = hex + "\n" + base64
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(hexAndBase64))}
 	filePath := additions[0].Path
 
@@ -255,7 +255,7 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 
 func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *testing.T) {
 	const creditCardNumber string = "340000000000009"
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(creditCardNumber))}
 	filePath := additions[0].Path
 

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultIgnoreEvaluator = *helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
+var defaultIgnoreEvaluator = helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
 
-func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.IgnoreEvaluator {
+func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) helpers.IgnoreEvaluator {
 	return helpers.BuildIgnoreEvaluator("default", tRC, gitrepo.RepoLocatedAt("."))
 }
 
@@ -177,7 +177,7 @@ func shouldNotFailWithDefaultDetectorAndIgnores(fileName, ignore string, thresho
 	talismanRC.IgnoreConfigs = []talismanrc.IgnoreConfig{fileIgnoreConfig}
 
 	DefaultFileNameDetector(threshold).
-		Test(*ignoreEvaluatorWithTalismanRC(talismanRC), additionsNamed(fileName), talismanRC, results, func() {})
+		Test(ignoreEvaluatorWithTalismanRC(talismanRC), additionsNamed(fileName), talismanRC, results, func() {})
 
 	assert.True(t,
 		results.Successful(),

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -173,7 +173,7 @@ func shouldNotFailWithDefaultDetectorAndIgnores(fileName, ignore string, thresho
 		FileName:        ignore,
 		IgnoreDetectors: []string{"filename"},
 	}
-	talismanRC, _ := talismanrc.For(talismanrc.HookMode)
+	talismanRC, _ := talismanrc.Load()
 	talismanRC.IgnoreConfigs = []talismanrc.IgnoreConfig{fileIgnoreConfig}
 
 	DefaultFileNameDetector(threshold).

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -144,7 +144,7 @@ func TestShouldIgnoreFilesWhenAskedToDoSoByIgnores(t *testing.T) {
 }
 
 func TestShouldIgnoreIfErrorIsBelowThreshold(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	fileName := ".bash_aliases"
 
 	DefaultFileNameDetector(severity.High).
@@ -168,7 +168,7 @@ func shouldIgnoreFilesWhichWouldOtherwiseTriggerErrors(
 }
 
 func shouldNotFailWithDefaultDetectorAndIgnores(fileName, ignore string, threshold severity.Severity, t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
 		FileName:        ignore,
 		IgnoreDetectors: []string{"filename"},
@@ -185,7 +185,7 @@ func shouldNotFailWithDefaultDetectorAndIgnores(fileName, ignore string, thresho
 }
 
 func shouldFailWithSpecificPattern(fileName, pattern string, threshold severity.Severity, t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	pt := []*severity.PatternSeverity{{Pattern: regexp.MustCompile(pattern), Severity: severity.Low}}
 
 	NewFileNameDetector(pt, threshold).
@@ -197,7 +197,7 @@ func shouldFailWithSpecificPattern(fileName, pattern string, threshold severity.
 }
 
 func shouldFailWithDefaultDetector(fileName, pattern string, severity severity.Severity, t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	DefaultFileNameDetector(severity).
 		Test(defaultIgnoreEvaluator, additionsNamed(fileName), talismanRC, results, func() {})
 	assert.True(t,

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultIgnoreEvaluator = *helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
+var defaultIgnoreEvaluator = helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
 
-func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.IgnoreEvaluator {
+func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) helpers.IgnoreEvaluator {
 	return helpers.BuildIgnoreEvaluator("default", tRC, gitrepo.RepoLocatedAt("."))
 }
 
@@ -58,6 +58,6 @@ func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {
 	}
 
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	NewFileSizeDetector(2).Test(*ignoreEvaluatorWithTalismanRC(talismanRC), additions, talismanRC, results, func() {})
+	NewFileSizeDetector(2).Test(ignoreEvaluatorWithTalismanRC(talismanRC), additions, talismanRC, results, func() {})
 	assert.True(t, results.Successful(), "expected file %s to be ignored by file size detector", filename)
 }

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -19,7 +19,7 @@ func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) helpers.IgnoreEva
 }
 
 func TestShouldFlagLargeFiles(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte("more than one byte")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
 	NewFileSizeDetector(2).Test(defaultIgnoreEvaluator, additions, talismanRC, results, func() {})
@@ -27,7 +27,7 @@ func TestShouldFlagLargeFiles(t *testing.T) {
 }
 
 func TestShouldNotFlagLargeFilesIfThresholdIsBelowSeverity(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte("more than one byte")
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
@@ -37,7 +37,7 @@ func TestShouldNotFlagLargeFilesIfThresholdIsBelowSeverity(t *testing.T) {
 }
 
 func TestShouldNotFlagSmallFiles(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte("m")
 	additions := []gitrepo.Addition{gitrepo.NewAddition("filename", content)}
 	NewFileSizeDetector(2).Test(defaultIgnoreEvaluator, additions, talismanRC, results, func() {})
@@ -45,7 +45,7 @@ func TestShouldNotFlagSmallFiles(t *testing.T) {
 }
 
 func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte("more than one byte")
 
 	filename := "filename"

--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -50,7 +50,6 @@ type ResultsSummary struct {
 // Currently, it keeps track of failures and ignored files.
 // The results are grouped by FilePath for easy reporting of all detected problems with individual files.
 type DetectionResults struct {
-	mode    talismanrc.Mode
 	Summary ResultsSummary   `json:"summary"`
 	Results []ResultsDetails `json:"results"`
 }
@@ -65,15 +64,13 @@ func (r *DetectionResults) getResultDetailsForFilePath(fileName gitrepo.FilePath
 }
 
 // NewDetectionResults is a new DetectionResults struct. It represents the pre-run state of a Detection run.
-func NewDetectionResults(mode talismanrc.Mode) *DetectionResults {
+func NewDetectionResults() *DetectionResults {
 	return &DetectionResults{
-		mode,
 		ResultsSummary{
 			FailureTypes{0, 0, 0, 0, 0},
 		},
 		make([]ResultsDetails, 0),
 	}
-
 }
 
 // Fail is used to mark the supplied FilePath as failing a detection for a supplied reason.
@@ -274,7 +271,7 @@ func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext p
 	if promptContext.Interactive && runtime.GOOS != "windows" {
 		confirmedEntries := getUserConfirmation(entriesToAdd, promptContext)
 		talismanrcConfig, _ := talismanrc.ConfigFromFile()
-		talismanrcConfig.AddIgnores(r.mode, confirmedEntries)
+		talismanrcConfig.AddIgnores(confirmedEntries)
 
 		for _, confirmedEntry := range confirmedEntries {
 			resultsDetails := r.getResultDetailsForFilePath(gitrepo.FilePath(confirmedEntry.GetFileName()))

--- a/detector/helpers/detection_results_test.go
+++ b/detector/helpers/detection_results_test.go
@@ -21,20 +21,20 @@ func init() {
 }
 
 func TestNewDetectionResultsAreSuccessful(t *testing.T) {
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 	assert.True(t, results.Successful(), "New detection result is always expected to succeed")
 	assert.False(t, results.HasFailures(), "New detection result is not expected to fail")
 }
 
 func TestCallingFailOnDetectionResultsFails(t *testing.T) {
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 	results.Fail("some_filename", "filename", "Bomb", []string{}, severity.Low)
 	assert.False(t, results.Successful(), "Calling fail on a result should not make it succeed")
 	assert.True(t, results.HasFailures(), "Calling fail on a result should make it fail")
 }
 
 func TestCanRecordMultipleErrorsAgainstASingleFile(t *testing.T) {
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 	results.Fail("some_filename", "filename", "Bomb", []string{}, severity.Low)
 	results.Fail("some_filename", "filename", "Complete & utter failure", []string{}, severity.Low)
 	results.Fail("another_filename", "filename", "Complete & utter failure", []string{}, severity.Low)
@@ -43,7 +43,7 @@ func TestCanRecordMultipleErrorsAgainstASingleFile(t *testing.T) {
 }
 
 func TestResultsReportsFailures(t *testing.T) {
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 	results.Fail("some_filename", "", "Bomb", []string{}, severity.Low)
 	results.Fail("some_filename", "", "Complete & utter failure", []string{}, severity.Low)
 	results.Fail("another_filename", "", "Complete & utter failure", []string{}, severity.Low)
@@ -59,7 +59,7 @@ func TestResultsReportsFailures(t *testing.T) {
 }
 
 func TestUpdateResultsSummary(t *testing.T) {
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 	categories := []string{"filecontent", "filename", "filesize"}
 
 	for _, category := range categories {
@@ -82,7 +82,7 @@ func TestErrorExitCodeInInteractive(t *testing.T) {
 	defer ctrl.Finish()
 
 	prompter := mock.NewMockPrompt(ctrl)
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 
 	promptContext := prompt.NewPromptContext(true, prompter)
 	prompter.EXPECT().Confirm(gomock.Any()).Return(false).Times(2)
@@ -97,7 +97,7 @@ func TestSuccessExitCodeInInteractive(t *testing.T) {
 	defer ctrl.Finish()
 
 	prompter := mock.NewMockPrompt(ctrl)
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 
 	promptContext := prompt.NewPromptContext(true, prompter)
 	prompter.EXPECT().Confirm(gomock.Any()).Return(true).Times(2)
@@ -107,28 +107,12 @@ func TestSuccessExitCodeInInteractive(t *testing.T) {
 	assert.False(t, results.HasFailures())
 }
 
-// Presently not showing the ignored files in the log
-// func TestLoggingIgnoredFilesDoesNotCauseFailure(t *testing.T) {
-// 	results := NewDetectionResults(talismanrc.HookMode)
-// 	results.Ignore("some_file", "some-detector")
-// 	results.Ignore("some/other_file", "some-other-detector")
-// 	results.Ignore("some_file_ignored_for_multiple_things", "some-detector")
-// 	results.Ignore("some_file_ignored_for_multiple_things", "some-other-detector")
-// 	assert.True(t, results.Successful(), "Calling ignore should keep the result successful.")
-// 	assert.True(t, results.HasIgnores(), "Calling ignore should be logged.")
-// 	assert.False(t, results.HasFailures(), "Calling ignore should not cause a result to fail.")
-
-// 	assert.Regexp(t, "some_file was ignored by .talismanrc for the following detectors: some-detector", results.Report(), "foo")
-// 	assert.Regexp(t, "some/other_file was ignored by .talismanrc for the following detectors: some-other-detector", results.Report(), "foo")
-// 	assert.Regexp(t, "some_file_ignored_for_multiple_things was ignored by .talismanrc for the following detectors: some-detector, some-other-detector", results.Report(), "foo")
-// }
-
 func TestTalismanRCSuggestionWhenThereAreFailures(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	prompter := mock.NewMockPrompt(ctrl)
-	results := NewDetectionResults(talismanrc.HookMode)
+	results := NewDetectionResults()
 
 	// Creating temp file with some content
 	fs := afero.NewMemMapFs()
@@ -208,7 +192,7 @@ version: "1.0"
 	t.Run("when user confirms, entry for existing file should updated", func(t *testing.T) {
 		promptContext := prompt.NewPromptContext(true, prompter)
 		prompter.EXPECT().Confirm("Do you want to add existing.pem with above checksum in talismanrc ?").Return(true)
-		results := NewDetectionResults(talismanrc.HookMode)
+		results := NewDetectionResults()
 		results.Fail("existing.pem", "filecontent", "This will bomb!", []string{}, severity.Low)
 
 		expectedFileContent := `fileignoreconfig:

--- a/detector/helpers/ignore_evaluator.go
+++ b/detector/helpers/ignore_evaluator.go
@@ -12,17 +12,35 @@ type IgnoreEvaluator interface {
 	ShouldIgnore(addition gitrepo.Addition, detectorType string) bool
 }
 
+type scanAllAdditions struct{}
+
+// Returns an IgnoreEvaluator that forces all files to be scanned, such as when scanning the history of a repo
+func ScanHistoryEvaluator() IgnoreEvaluator {
+	return &scanAllAdditions{}
+}
+
+// Returns false so that all additions are scanned
+func (ie *scanAllAdditions) ShouldIgnore(gitrepo.Addition, string) bool {
+	return false
+}
+
 type ignoreEvaluator struct {
 	calculator checksumcalculator.ChecksumCalculator
 	talismanRC *talismanrc.TalismanRC
 }
 
+// Returns an IgnoreEvaluator around the rules defined in the current .talismanrc file
 func BuildIgnoreEvaluator(hasherMode string, talismanRC *talismanrc.TalismanRC, repo gitrepo.GitRepo) IgnoreEvaluator {
 	wd, _ := os.Getwd()
 	hasher := utility.MakeHasher(hasherMode, wd)
 	allTrackedFiles := append(repo.TrackedFilesAsAdditions(), repo.StagedAdditions()...)
 	calculator := checksumcalculator.NewChecksumCalculator(hasher, allTrackedFiles)
 	return &ignoreEvaluator{calculator: calculator, talismanRC: talismanRC}
+}
+
+// ShouldIgnore returns true if the talismanRC indicates that a Detector should ignore an Addition
+func (ie *ignoreEvaluator) ShouldIgnore(addition gitrepo.Addition, detectorType string) bool {
+	return ie.talismanRC.Deny(addition, detectorType) || ie.isScanNotRequired(addition)
 }
 
 // isScanNotRequired returns true if an Addition's checksum matches one ignored by the .talismanrc file
@@ -34,9 +52,4 @@ func (ie *ignoreEvaluator) isScanNotRequired(addition gitrepo.Addition) bool {
 		}
 	}
 	return false
-}
-
-// ShouldIgnore returns true if the talismanRC indicates that a Detector should ignore an Addition
-func (ie *ignoreEvaluator) ShouldIgnore(addition gitrepo.Addition, detectorType string) bool {
-	return ie.talismanRC.Deny(addition, detectorType) || ie.isScanNotRequired(addition)
 }

--- a/detector/helpers/ignore_evaluator_test.go
+++ b/detector/helpers/ignore_evaluator_test.go
@@ -22,7 +22,7 @@ func TestIsScanNotRequired(t *testing.T) {
 		ignoreConfig := &talismanrc.TalismanRC{
 			IgnoreConfigs: []talismanrc.IgnoreConfig{},
 		}
-		ie := IgnoreEvaluator{nil, ignoreConfig}
+		ie := ignoreEvaluator{nil, ignoreConfig}
 		addition := gitrepo.Addition{Path: "some.txt"}
 
 		required := ie.isScanNotRequired(addition)
@@ -42,7 +42,7 @@ func TestIsScanNotRequired(t *testing.T) {
 				},
 			},
 		}
-		ie := IgnoreEvaluator{calculator: checksumCalculator, talismanRC: &ignoreConfig}
+		ie := ignoreEvaluator{calculator: checksumCalculator, talismanRC: &ignoreConfig}
 		addition := gitrepo.Addition{Name: "some.txt", Path: "some.txt"}
 		checksumCalculator.EXPECT().CalculateCollectiveChecksumForPattern("some.txt").Return("sha1")
 
@@ -79,7 +79,7 @@ func TestDeterminingFilesToIgnore(t *testing.T) {
 			},
 		},
 	}
-	ie := IgnoreEvaluator{&sillyChecksumCalculator{}, &tRC}
+	ie := ignoreEvaluator{&sillyChecksumCalculator{}, &tRC}
 
 	t.Run("Should ignore file based on checksum", func(t *testing.T) {
 		assert.True(t, ie.ShouldIgnore(gitrepo.Addition{Path: "some.txt"}, ""))

--- a/detector/helpers/ignore_evaluator_test.go
+++ b/detector/helpers/ignore_evaluator_test.go
@@ -97,3 +97,8 @@ func TestDeterminingFilesToIgnore(t *testing.T) {
 		assert.False(t, ie.ShouldIgnore(gitrepo.Addition{Path: "ignore-contents"}, "filename"))
 	})
 }
+
+func TestNeverIgnoreFilesForHistory(t *testing.T) {
+	scanAllEvaluator := ScanHistoryEvaluator()
+	assert.False(t, scanAllEvaluator.ShouldIgnore(gitrepo.Addition{Name: "any-file"}, "any_detector"))
+}

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 var talismanRC = &talismanrc.TalismanRC{}
-var defaultIgnoreEvaluator = *helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
+var defaultIgnoreEvaluator = helpers.BuildIgnoreEvaluator("default", talismanRC, gitrepo.RepoLocatedAt("."))
 var dummyCallback = func() {}
 
 var (
 	customPatterns []talismanrc.PatternString
 )
 
-func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) *helpers.IgnoreEvaluator {
+func ignoreEvaluatorWithTalismanRC(tRC *talismanrc.TalismanRC) helpers.IgnoreEvaluator {
 	return helpers.BuildIgnoreEvaluator("default", tRC, gitrepo.RepoLocatedAt("."))
 }
 
@@ -77,7 +77,7 @@ func TestShouldIgnorePasswordPatternsIfChecksumMatches(t *testing.T) {
 		AllowedPatterns: []string{}}
 	ignores := &talismanrc.TalismanRC{IgnoreConfigs: []talismanrc.IgnoreConfig{fileIgnoreConfig}}
 
-	NewPatternDetector(customPatterns).Test(*ignoreEvaluatorWithTalismanRC(ignores), additions, ignores, results, dummyCallback)
+	NewPatternDetector(customPatterns).Test(ignoreEvaluatorWithTalismanRC(ignores), additions, ignores, results, dummyCallback)
 
 	assert.True(t, results.Successful(), "Expected file %s to be ignored because checksum matches", filename)
 }
@@ -108,7 +108,7 @@ func TestShouldOnlyWarnSecretPatternIfBelowThreshold(t *testing.T) {
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 	talismanRCWithThreshold := &talismanrc.TalismanRC{Threshold: severity.High}
 
-	NewPatternDetector(customPatterns).Test(*ignoreEvaluatorWithTalismanRC(talismanRCWithThreshold), additions, talismanRCWithThreshold, results, dummyCallback)
+	NewPatternDetector(customPatterns).Test(ignoreEvaluatorWithTalismanRC(talismanRCWithThreshold), additions, talismanRCWithThreshold, results, dummyCallback)
 
 	assert.False(t, results.HasFailures(), "Expected file %s to not have failures", filename)
 	assert.True(t, results.HasWarnings(), "Expected file %s to have warnings", filename)

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -66,7 +66,7 @@ func TestShouldDetectPasswordPatterns(t *testing.T) {
 }
 
 func TestShouldIgnorePasswordPatternsIfChecksumMatches(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte("\"password\" : UnsafePassword")
 	filename := "secret.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
@@ -83,7 +83,7 @@ func TestShouldIgnorePasswordPatternsIfChecksumMatches(t *testing.T) {
 }
 
 func TestShouldIgnoreAllowedPattern(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte("\"key\" : \"This is an allowed keyword\"\npassword=y0uw1lln3v3rgu3ssmyP@55w0rd")
 	filename := "allowed_pattern.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
@@ -102,7 +102,7 @@ func TestShouldIgnoreAllowedPattern(t *testing.T) {
 		"Expected keywords %v %v to be ignored by Talisman", fileIgnoreConfig.AllowedPatterns, ignores.AllowedPatterns)
 }
 func TestShouldOnlyWarnSecretPatternIfBelowThreshold(t *testing.T) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	content := []byte(`password=UnsafeString`)
 	filename := "secret.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
@@ -115,7 +115,7 @@ func TestShouldOnlyWarnSecretPatternIfBelowThreshold(t *testing.T) {
 }
 
 func DetectionOfSecretPattern(filename string, content []byte) (*helpers.DetectionResults, []gitrepo.Addition, string) {
-	results := helpers.NewDetectionResults(talismanrc.HookMode)
+	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
 	NewPatternDetector(customPatterns).Test(defaultIgnoreEvaluator, additions, talismanRC, results, dummyCallback)
 	expected := "Potential secret pattern : " + string(content)

--- a/talismanrc/rc_file_test.go
+++ b/talismanrc/rc_file_test.go
@@ -22,7 +22,7 @@ custom_patterns:
 	}
 	t.Run("talismanrc should not fail as long as the yaml structure is correct", func(t *testing.T) {
 		setRepoFileReader(repoFileReader)
-		rc, _ := For(HookMode)
+		rc, _ := Load()
 		assert.Equal(t, 1, len(rc.IgnoreConfigs))
 		assert.Equal(t, 1, len(rc.CustomPatterns))
 	})
@@ -35,9 +35,7 @@ func TestShouldIgnoreUnformattedFiles(t *testing.T) {
 			return []byte(s), nil
 		})
 
-		talismanRC, _ := For(HookMode)
-		assert.True(t, talismanRC.AcceptsAll(), "Expected commented line '%s' to result in no ignore patterns", s)
-		talismanRC, _ = For(ScanMode)
+		talismanRC, _ := Load()
 		assert.True(t, talismanRC.AcceptsAll(), "Expected commented line '%s' to result in no ignore patterns", s)
 	}
 	setRepoFileReader(defaultRepoFileReader)
@@ -61,7 +59,7 @@ func TestFor(t *testing.T) {
 	}
 	t.Run("talismanrc.For(mode) should read multiple entries in rc file correctly", func(t *testing.T) {
 		setRepoFileReader(repoFileReader)
-		rc, _ := For(HookMode)
+		rc, _ := Load()
 		assert.Equal(t, 3, len(rc.IgnoreConfigs))
 
 		assert.Equal(t, rc.IgnoreConfigs[0].GetFileName(), "testfile_1.yml")
@@ -72,23 +70,5 @@ func TestFor(t *testing.T) {
 		assert.True(t, rc.IgnoreConfigs[2].ChecksumMatches("file3_checksum"))
 
 		setRepoFileReader(defaultRepoFileReader)
-	})
-
-	t.Run("talismanrc.ForScan(ignoreHistory) should populate talismanrc for scan mode with ignore history", func(t *testing.T) {
-		setRepoFileReader(repoFileReader)
-		rc, _ := ForScan(true)
-
-		assert.Equal(t, 3, len(rc.IgnoreConfigs))
-		setRepoFileReader(defaultRepoFileReader)
-
-	})
-
-	t.Run("talismanrc.ForScan(ignoreHistory) should populate talismanrc for scan mode without ignore history", func(t *testing.T) {
-		setRepoFileReader(repoFileReader)
-		rc, _ := ForScan(false)
-
-		assert.Equal(t, 0, len(rc.IgnoreConfigs))
-		setRepoFileReader(defaultRepoFileReader)
-
 	})
 }

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -13,14 +13,6 @@ import (
 	"talisman/gitrepo"
 )
 
-type Mode int
-type CommitID string
-
-const (
-	HookMode = Mode(iota + 1)
-	ScanMode
-)
-
 type TalismanRC struct {
 	IgnoreConfigs    []IgnoreConfig         `yaml:"-"`
 	ScopeConfig      []ScopeConfig          `yaml:"-"`
@@ -96,18 +88,18 @@ func (tRC *TalismanRC) FilterAdditions(additions []gitrepo.Addition) []gitrepo.A
 	return result
 }
 
-func (tRC *persistedRC) AddIgnores(mode Mode, entriesToAdd []IgnoreConfig) {
+func (tRC *persistedRC) AddIgnores(entriesToAdd []IgnoreConfig) {
 	if len(entriesToAdd) > 0 {
 		logr.Debugf("Adding entries: %v", entriesToAdd)
 		talismanRCConfig, _ := ConfigFromFile()
-		if mode == HookMode {
-			fileIgnoreEntries := make([]FileIgnoreConfig, len(entriesToAdd))
-			for idx, entry := range entriesToAdd {
-				newVal, _ := entry.(*FileIgnoreConfig)
-				fileIgnoreEntries[idx] = *newVal
-			}
-			talismanRCConfig.FileIgnoreConfig = combineFileIgnores(talismanRCConfig.FileIgnoreConfig, fileIgnoreEntries)
+
+		fileIgnoreEntries := make([]FileIgnoreConfig, len(entriesToAdd))
+		for idx, entry := range entriesToAdd {
+			newVal, _ := entry.(*FileIgnoreConfig)
+			fileIgnoreEntries[idx] = *newVal
 		}
+		talismanRCConfig.FileIgnoreConfig = combineFileIgnores(talismanRCConfig.FileIgnoreConfig, fileIgnoreEntries)
+
 		ignoreEntries, _ := yaml.Marshal(&talismanRCConfig)
 		file, err := fs.OpenFile(currentRCFileName, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -193,7 +193,7 @@ func (tRC *TalismanRC) effectiveRules(detectorName string) []string {
 	return result
 }
 
-func fromPersistedRC(configFromTalismanRCFile *persistedRC, mode Mode) *TalismanRC {
+func fromPersistedRC(configFromTalismanRCFile *persistedRC) *TalismanRC {
 	tRC := TalismanRC{}
 
 	tRC.Threshold = configFromTalismanRCFile.Threshold
@@ -206,32 +206,23 @@ func fromPersistedRC(configFromTalismanRCFile *persistedRC, mode Mode) *Talisman
 		tRC.AllowedPatterns[i] = regexp.MustCompile(p)
 	}
 
-	if mode == HookMode {
-		tRC.IgnoreConfigs = make(
-			[]IgnoreConfig,
-			len(configFromTalismanRCFile.FileIgnoreConfig),
-		)
+	tRC.IgnoreConfigs = make(
+		[]IgnoreConfig,
+		len(configFromTalismanRCFile.FileIgnoreConfig),
+	)
 
-		for i := range configFromTalismanRCFile.FileIgnoreConfig {
-			tRC.IgnoreConfigs[i] = &configFromTalismanRCFile.FileIgnoreConfig[i]
-		}
+	for i := range configFromTalismanRCFile.FileIgnoreConfig {
+		tRC.IgnoreConfigs[i] = &configFromTalismanRCFile.FileIgnoreConfig[i]
 	}
 	tRC.base = configFromTalismanRCFile
 
 	return &tRC
 }
 
-func For(mode Mode) (*TalismanRC, error) {
+func Load() (*TalismanRC, error) {
 	configFromTalismanRCFile, err := ConfigFromFile()
-	talismanRC := fromPersistedRC(configFromTalismanRCFile, mode)
+	talismanRC := fromPersistedRC(configFromTalismanRCFile)
 	return talismanRC, err
-}
-
-func ForScan(ignoreHistory bool) (*TalismanRC, error) {
-	if ignoreHistory {
-		return For(HookMode)
-	}
-	return For(ScanMode)
 }
 
 func ConfigFromFile() (*persistedRC, error) {

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -137,7 +137,7 @@ func TestAddIgnoreFilesInHookMode(t *testing.T) {
 		AllowedPatterns: []string{}}
 	os.Remove(DefaultRCFileName)
 	talismanRCConfig := createTalismanRCWithScopeIgnores([]string{})
-	talismanRCConfig.base.AddIgnores(HookMode, []IgnoreConfig{ignoreConfig})
+	talismanRCConfig.base.AddIgnores([]IgnoreConfig{ignoreConfig})
 	talismanRCConfigFromFile, _ := ConfigFromFile()
 	assert.Equal(t, 1, len(talismanRCConfigFromFile.FileIgnoreConfig))
 	os.Remove(DefaultRCFileName)

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -50,7 +50,7 @@ custom_severities:
   severity: low
 `)
 	persistedRC, _ := newPersistedRC(talismanRCContents)
-	talismanRC := fromPersistedRC(persistedRC, ScanMode)
+	talismanRC := fromPersistedRC(persistedRC)
 	assert.Equal(t, persistedRC.Threshold, severity.High)
 	assert.Equal(t, len(persistedRC.CustomSeverities), 1)
 	assert.Equal(t, persistedRC.CustomSeverities, talismanRC.CustomSeverities)


### PR DESCRIPTION
Simplify (remove) logic that loads the TalismanRC struct from a .talismanrc file in different ways to account for different file ignore behavior when scanning history vs scanning HEAD or a single changeset. Instead, encapsulate this logic in the IgnoreEvaluator.