### PR TITLE
Use a single struct for TalismanRC

### DIFF
--- a/checksumcalculator/checksumcalculator.go
+++ b/checksumcalculator/checksumcalculator.go
@@ -31,8 +31,7 @@ func (cc *checksumCalculator) SuggestTalismanRC(fileNamePatterns []string) strin
 	for _, pattern := range fileNamePatterns {
 		collectiveChecksum := cc.CalculateCollectiveChecksumForPattern(pattern)
 		if collectiveChecksum != "" {
-			fileIgnoreConfig := talismanrc.FileIgnoreConfig{FileName: pattern, Checksum: collectiveChecksum, IgnoreDetectors: []string{}}
-			fileIgnoreConfigs = append(fileIgnoreConfigs, fileIgnoreConfig)
+			fileIgnoreConfigs = append(fileIgnoreConfigs, talismanrc.IgnoreFileWithChecksum(pattern, collectiveChecksum))
 		}
 	}
 	if len(fileIgnoreConfigs) != 0 {

--- a/checksumcalculator/checksumcalculator.go
+++ b/checksumcalculator/checksumcalculator.go
@@ -5,8 +5,6 @@ import (
 	"talisman/gitrepo"
 	"talisman/talismanrc"
 	"talisman/utility"
-
-	"gopkg.in/yaml.v2"
 )
 
 type ChecksumCalculator interface {
@@ -36,9 +34,7 @@ func (cc *checksumCalculator) SuggestTalismanRC(fileNamePatterns []string) strin
 	}
 	if len(fileIgnoreConfigs) != 0 {
 		result.WriteString("\n\x1b[33m.talismanrc format for given file names / patterns\x1b[0m\n")
-		talismanRC := talismanrc.MakeWithFileIgnores(fileIgnoreConfigs)
-		m, _ := yaml.Marshal(&talismanRC)
-		result.Write(m)
+		result.Write([]byte(talismanrc.SuggestRCFor(fileIgnoreConfigs)))
 	}
 	return result.String()
 }

--- a/cmd/scanner_cmd_test.go
+++ b/cmd/scanner_cmd_test.go
@@ -63,9 +63,9 @@ func TestScannerCmdDetectsSecretAndIgnoresWhileRunningInIgnoreHistoryModeWithVal
 		os.Chdir(git.GetRoot())
 
 		tRC := &talismanrc.TalismanRC{
-			IgnoreConfigs: []talismanrc.IgnoreConfig{
-				&talismanrc.FileIgnoreConfig{FileName: "go.sum", Checksum: "582093519ae682d5170aecc9b935af7e90ed528c577ecd2c9dd1fad8f4924ab9"},
-				&talismanrc.FileIgnoreConfig{FileName: "go.mod", Checksum: "8a03b9b61c505ace06d590d2b9b4f4b6fa70136e14c26875ced149180e00d1af"},
+			FileIgnoreConfig: []talismanrc.FileIgnoreConfig{
+				{FileName: "go.sum", Checksum: "582093519ae682d5170aecc9b935af7e90ed528c577ecd2c9dd1fad8f4924ab9"},
+				{FileName: "go.mod", Checksum: "8a03b9b61c505ace06d590d2b9b4f4b6fa70136e14c26875ced149180e00d1af"},
 			}}
 		scannerCmd := NewScannerCmd(true, tRC, git.GetRoot())
 		scannerCmd.Run()
@@ -82,9 +82,9 @@ func TestScannerCmdDetectsSecretWhileRunningNormalScanMode(t *testing.T) {
 		os.Chdir(git.GetRoot())
 
 		tRC := &talismanrc.TalismanRC{
-			IgnoreConfigs: []talismanrc.IgnoreConfig{
-				&talismanrc.FileIgnoreConfig{FileName: "go.sum", Checksum: "582093519ae682d5170aecc9b935af7e90ed528c577ecd2c9dd1fad8f4924ab9"},
-				&talismanrc.FileIgnoreConfig{FileName: "go.mod", Checksum: "8a03b9b61c505ace06d590d2b9b4f4b6fa70136e14c26875ced149180e00d1af"},
+			FileIgnoreConfig: []talismanrc.FileIgnoreConfig{
+				{FileName: "go.sum", Checksum: "582093519ae682d5170aecc9b935af7e90ed528c577ecd2c9dd1fad8f4924ab9"},
+				{FileName: "go.mod", Checksum: "8a03b9b61c505ace06d590d2b9b4f4b6fa70136e14c26875ced149180e00d1af"},
 			}}
 		scannerCmd := NewScannerCmd(false, tRC, git.GetRoot())
 		scannerCmd.Run()

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var emptyTalismanRC = &talismanrc.TalismanRC{IgnoreConfigs: []talismanrc.IgnoreConfig{}}
+var emptyTalismanRC = &talismanrc.TalismanRC{FileIgnoreConfig: []talismanrc.FileIgnoreConfig{}}
 var defaultIgnoreEvaluator = helpers.BuildIgnoreEvaluator("default", emptyTalismanRC, gitrepo.RepoLocatedAt("."))
 var dummyCallback = func() {}
 var filename = "filename"
@@ -31,8 +31,8 @@ func TestShouldIgnoreFileIfNeeded(t *testing.T) {
 	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte("prettySafe"))}
 	talismanRCIWithFilenameIgnore := &talismanrc.TalismanRC{
-		IgnoreConfigs: []talismanrc.IgnoreConfig{
-			&talismanrc.FileIgnoreConfig{FileName: filename},
+		FileIgnoreConfig: []talismanrc.FileIgnoreConfig{
+			{FileName: filename},
 		},
 	}
 
@@ -204,12 +204,12 @@ func TestShouldNotFlagPotentialSecretsIfIgnored(t *testing.T) {
 func TestResultsShouldNotFlagCreditCardNumberIfSpecifiedInFileIgnores(t *testing.T) {
 	const creditCardNumber string = "340000000000009"
 	results := helpers.NewDetectionResults()
-	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{
 		FileName: filename, Checksum: "",
 		AllowedPatterns: []string{creditCardNumber},
 	}
 	talismanRCWithFileIgnore := &talismanrc.TalismanRC{
-		IgnoreConfigs: []talismanrc.IgnoreConfig{fileIgnoreConfig},
+		FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig},
 	}
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(creditCardNumber))}
 

--- a/detector/filecontent/filecontent_detector_test.go
+++ b/detector/filecontent/filecontent_detector_test.go
@@ -191,7 +191,7 @@ func TestShouldNotFlagPotentialCreditCardNumberIfAboveThreshold(t *testing.T) {
 func TestShouldNotFlagPotentialSecretsIfIgnored(t *testing.T) {
 	const hex string = "68656C6C6F20776F726C6421"
 	talismanRCWithIgnores := &talismanrc.TalismanRC{
-		AllowedPatterns: []*regexp.Regexp{regexp.MustCompile("[0-9a-fA-F]*")}}
+		AllowedPatterns: []*talismanrc.Pattern{{Regexp: regexp.MustCompile("[0-9a-fA-F]*")}}}
 	results := helpers.NewDetectionResults()
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, []byte(hex))}
 

--- a/detector/filename/filename_detector_test.go
+++ b/detector/filename/filename_detector_test.go
@@ -169,12 +169,12 @@ func shouldIgnoreFilesWhichWouldOtherwiseTriggerErrors(
 
 func shouldNotFailWithDefaultDetectorAndIgnores(fileName, ignore string, threshold severity.Severity, t *testing.T) {
 	results := helpers.NewDetectionResults()
-	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{
 		FileName:        ignore,
 		IgnoreDetectors: []string{"filename"},
 	}
 	talismanRC, _ := talismanrc.Load()
-	talismanRC.IgnoreConfigs = []talismanrc.IgnoreConfig{fileIgnoreConfig}
+	talismanRC.FileIgnoreConfig = []talismanrc.FileIgnoreConfig{fileIgnoreConfig}
 
 	DefaultFileNameDetector(threshold).
 		Test(ignoreEvaluatorWithTalismanRC(talismanRC), additionsNamed(fileName), talismanRC, results, func() {})

--- a/detector/filesize/filesize_detector_test.go
+++ b/detector/filesize/filesize_detector_test.go
@@ -49,12 +49,12 @@ func TestShouldNotFlagIgnoredLargeFiles(t *testing.T) {
 	content := []byte("more than one byte")
 
 	filename := "filename"
-	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{
 		FileName:        filename,
 		IgnoreDetectors: []string{"filesize"},
 	}
 	talismanRC := &talismanrc.TalismanRC{
-		IgnoreConfigs: []talismanrc.IgnoreConfig{fileIgnoreConfig},
+		FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig},
 	}
 
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}

--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -260,11 +260,11 @@ func (r *DetectionResults) Report(promptContext prompt.PromptContext, mode strin
 }
 
 func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext prompt.PromptContext, mode string) {
-	var entriesToAdd []talismanrc.IgnoreConfig
+	var entriesToAdd []talismanrc.FileIgnoreConfig
 	hasher := utility.MakeHasher(mode, ".")
 	for _, filePath := range filePaths {
 		currentChecksum := hasher.CollectiveSHA256Hash([]string{filePath})
-		fileIgnoreConfig := talismanrc.BuildIgnoreConfig(filePath, currentChecksum, []string{})
+		fileIgnoreConfig := talismanrc.IgnoreFileWithChecksum(filePath, currentChecksum)
 		entriesToAdd = append(entriesToAdd, fileIgnoreConfig)
 	}
 
@@ -291,8 +291,8 @@ func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext p
 
 }
 
-func getUserConfirmation(configs []talismanrc.IgnoreConfig, promptContext prompt.PromptContext) []talismanrc.IgnoreConfig {
-	confirmed := []talismanrc.IgnoreConfig{}
+func getUserConfirmation(configs []talismanrc.FileIgnoreConfig, promptContext prompt.PromptContext) []talismanrc.FileIgnoreConfig {
+	confirmed := []talismanrc.FileIgnoreConfig{}
 	if len(configs) != 0 {
 		fmt.Println("==== Interactively adding to talismanrc ====")
 	}
@@ -304,7 +304,7 @@ func getUserConfirmation(configs []talismanrc.IgnoreConfig, promptContext prompt
 	return confirmed
 }
 
-func printTalismanIgnoreSuggestion(entriesToAdd []talismanrc.IgnoreConfig) {
+func printTalismanIgnoreSuggestion(entriesToAdd []talismanrc.FileIgnoreConfig) {
 	ignoreEntries := talismanrc.SuggestRCFor(entriesToAdd)
 	suggestString := fmt.Sprintf("\n\x1b[33mIf you are absolutely sure that you want to ignore the " +
 		"above files from talisman detectors, consider pasting the following format in .talismanrc file" +
@@ -313,7 +313,7 @@ func printTalismanIgnoreSuggestion(entriesToAdd []talismanrc.IgnoreConfig) {
 	fmt.Println(ignoreEntries)
 }
 
-func confirm(config talismanrc.IgnoreConfig, promptContext prompt.PromptContext) bool {
+func confirm(config talismanrc.FileIgnoreConfig, promptContext prompt.PromptContext) bool {
 	bytes, err := yaml.Marshal(&config)
 	if err != nil {
 		logrus.Errorf("error marshalling file ignore config: %s", err)

--- a/detector/helpers/detection_results.go
+++ b/detector/helpers/detection_results.go
@@ -270,7 +270,7 @@ func (r *DetectionResults) suggestTalismanRC(filePaths []string, promptContext p
 
 	if promptContext.Interactive && runtime.GOOS != "windows" {
 		confirmedEntries := getUserConfirmation(entriesToAdd, promptContext)
-		talismanrcConfig, _ := talismanrc.ConfigFromFile()
+		talismanrcConfig, _ := talismanrc.Load()
 		talismanrcConfig.AddIgnores(confirmedEntries)
 
 		for _, confirmedEntry := range confirmedEntries {

--- a/detector/helpers/ignore_evaluator.go
+++ b/detector/helpers/ignore_evaluator.go
@@ -45,7 +45,7 @@ func (ie *ignoreEvaluator) ShouldIgnore(addition gitrepo.Addition, detectorType 
 
 // isScanNotRequired returns true if an Addition's checksum matches one ignored by the .talismanrc file
 func (ie *ignoreEvaluator) isScanNotRequired(addition gitrepo.Addition) bool {
-	for _, ignore := range ie.talismanRC.IgnoreConfigs {
+	for _, ignore := range ie.talismanRC.FileIgnoreConfig {
 		if addition.Matches(ignore.GetFileName()) {
 			currentCollectiveChecksum := ie.calculator.CalculateCollectiveChecksumForPattern(ignore.GetFileName())
 			return ignore.ChecksumMatches(currentCollectiveChecksum)

--- a/detector/helpers/ignore_evaluator_test.go
+++ b/detector/helpers/ignore_evaluator_test.go
@@ -20,7 +20,7 @@ func TestIsScanNotRequired(t *testing.T) {
 
 	t.Run("should return false if talismanrc is empty", func(t *testing.T) {
 		ignoreConfig := &talismanrc.TalismanRC{
-			IgnoreConfigs: []talismanrc.IgnoreConfig{},
+			FileIgnoreConfig: []talismanrc.FileIgnoreConfig{},
 		}
 		ie := ignoreEvaluator{nil, ignoreConfig}
 		addition := gitrepo.Addition{Path: "some.txt"}
@@ -35,8 +35,8 @@ func TestIsScanNotRequired(t *testing.T) {
 		defer ctrl.Finish()
 		checksumCalculator := mockchecksumcalculator.NewMockChecksumCalculator(ctrl)
 		ignoreConfig := talismanrc.TalismanRC{
-			IgnoreConfigs: []talismanrc.IgnoreConfig{
-				&talismanrc.FileIgnoreConfig{
+			FileIgnoreConfig: []talismanrc.FileIgnoreConfig{
+				{
 					FileName: "some.txt",
 					Checksum: "sha1",
 				},
@@ -64,16 +64,16 @@ func (scc *sillyChecksumCalculator) SuggestTalismanRC(fileNamePatterns []string)
 
 func TestDeterminingFilesToIgnore(t *testing.T) {
 	tRC := talismanrc.TalismanRC{
-		IgnoreConfigs: []talismanrc.IgnoreConfig{
-			&talismanrc.FileIgnoreConfig{
+		FileIgnoreConfig: []talismanrc.FileIgnoreConfig{
+			{
 				FileName: "some.txt",
 				Checksum: "silly",
 			},
-			&talismanrc.FileIgnoreConfig{
+			{
 				FileName: "other.txt",
 				Checksum: "serious",
 			},
-			&talismanrc.FileIgnoreConfig{
+			{
 				FileName:        "ignore-contents",
 				IgnoreDetectors: []string{"filecontent"},
 			},

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -93,7 +93,7 @@ func TestShouldIgnoreAllowedPattern(t *testing.T) {
 		AllowedPatterns: []string{"key"}}
 	ignores := &talismanrc.TalismanRC{
 		FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig},
-		AllowedPatterns:  []*regexp.Regexp{regexp.MustCompile("password")}}
+		AllowedPatterns:  []*talismanrc.Pattern{{Regexp: regexp.MustCompile("password")}}}
 
 	NewPatternDetector(customPatterns).Test(defaultIgnoreEvaluator, additions, ignores, results, dummyCallback)
 

--- a/detector/pattern/pattern_detector_test.go
+++ b/detector/pattern/pattern_detector_test.go
@@ -70,12 +70,12 @@ func TestShouldIgnorePasswordPatternsIfChecksumMatches(t *testing.T) {
 	content := []byte("\"password\" : UnsafePassword")
 	filename := "secret.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{
 		FileName:        filename,
 		Checksum:        "833b6c24c8c2c5c7e1663226dc401b29c005492dc76a1150fc0e0f07f29d4cc3",
 		IgnoreDetectors: []string{"filecontent"},
 		AllowedPatterns: []string{}}
-	ignores := &talismanrc.TalismanRC{IgnoreConfigs: []talismanrc.IgnoreConfig{fileIgnoreConfig}}
+	ignores := &talismanrc.TalismanRC{FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig}}
 
 	NewPatternDetector(customPatterns).Test(ignoreEvaluatorWithTalismanRC(ignores), additions, ignores, results, dummyCallback)
 
@@ -87,13 +87,13 @@ func TestShouldIgnoreAllowedPattern(t *testing.T) {
 	content := []byte("\"key\" : \"This is an allowed keyword\"\npassword=y0uw1lln3v3rgu3ssmyP@55w0rd")
 	filename := "allowed_pattern.txt"
 	additions := []gitrepo.Addition{gitrepo.NewAddition(filename, content)}
-	fileIgnoreConfig := &talismanrc.FileIgnoreConfig{
+	fileIgnoreConfig := talismanrc.FileIgnoreConfig{
 		FileName: filename, Checksum: "",
 		IgnoreDetectors: []string{},
 		AllowedPatterns: []string{"key"}}
 	ignores := &talismanrc.TalismanRC{
-		IgnoreConfigs:   []talismanrc.IgnoreConfig{fileIgnoreConfig},
-		AllowedPatterns: []*regexp.Regexp{regexp.MustCompile("password")}}
+		FileIgnoreConfig: []talismanrc.FileIgnoreConfig{fileIgnoreConfig},
+		AllowedPatterns:  []*regexp.Regexp{regexp.MustCompile("password")}}
 
 	NewPatternDetector(customPatterns).Test(defaultIgnoreEvaluator, additions, ignores, results, dummyCallback)
 

--- a/talismanrc/rc_file.go
+++ b/talismanrc/rc_file.go
@@ -21,7 +21,7 @@ var (
 	currentRCFileName = DefaultRCFileName
 )
 
-func readConfigFromRCFile(fileReader func(string) ([]byte, error)) (*persistedRC, error) {
+func readConfigFromRCFile(fileReader func(string) ([]byte, error)) (*TalismanRC, error) {
 	fileContents, err := fileReader(currentRCFileName)
 	if err != nil {
 		panic(err)
@@ -29,13 +29,13 @@ func readConfigFromRCFile(fileReader func(string) ([]byte, error)) (*persistedRC
 	return newPersistedRC(fileContents)
 }
 
-func newPersistedRC(fileContents []byte) (*persistedRC, error) {
-	talismanRCFromFile := persistedRC{}
+func newPersistedRC(fileContents []byte) (*TalismanRC, error) {
+	talismanRCFromFile := TalismanRC{}
 	err := yaml.Unmarshal(fileContents, &talismanRCFromFile)
 	if err != nil {
 		logr.Errorf("Unable to parse .talismanrc : %v", err)
 		fmt.Println(fmt.Errorf("\n\x1b[1m\x1b[31mUnable to parse .talismanrc %s. Please ensure it is following the right YAML structure\x1b[0m\x1b[0m", err))
-		return &persistedRC{}, err
+		return &TalismanRC{}, err
 	}
 	if talismanRCFromFile.Version == "" {
 		talismanRCFromFile.Version = DefaultRCVersion
@@ -54,7 +54,6 @@ func SetRcFilename__(rcFileName string) {
 type RepoFileReader func(string) ([]byte, error)
 
 var repoFileReader = func() RepoFileReader {
-
 	return func(path string) ([]byte, error) {
 		data, err := utility.SafeReadFile(path)
 		if err != nil {

--- a/talismanrc/rc_file_test.go
+++ b/talismanrc/rc_file_test.go
@@ -23,7 +23,7 @@ custom_patterns:
 	t.Run("talismanrc should not fail as long as the yaml structure is correct", func(t *testing.T) {
 		setRepoFileReader(repoFileReader)
 		rc, _ := Load()
-		assert.Equal(t, 1, len(rc.IgnoreConfigs))
+		assert.Equal(t, 1, len(rc.FileIgnoreConfig))
 		assert.Equal(t, 1, len(rc.CustomPatterns))
 	})
 	setRepoFileReader(defaultRepoFileReader)
@@ -60,14 +60,14 @@ func TestFor(t *testing.T) {
 	t.Run("talismanrc.For(mode) should read multiple entries in rc file correctly", func(t *testing.T) {
 		setRepoFileReader(repoFileReader)
 		rc, _ := Load()
-		assert.Equal(t, 3, len(rc.IgnoreConfigs))
+		assert.Equal(t, 3, len(rc.FileIgnoreConfig))
 
-		assert.Equal(t, rc.IgnoreConfigs[0].GetFileName(), "testfile_1.yml")
-		assert.True(t, rc.IgnoreConfigs[0].ChecksumMatches("file1_checksum"))
-		assert.Equal(t, rc.IgnoreConfigs[1].GetFileName(), "testfile_2.yml")
-		assert.True(t, rc.IgnoreConfigs[1].ChecksumMatches("file2_checksum"))
-		assert.Equal(t, rc.IgnoreConfigs[2].GetFileName(), "testfile_3.yml")
-		assert.True(t, rc.IgnoreConfigs[2].ChecksumMatches("file3_checksum"))
+		assert.Equal(t, rc.FileIgnoreConfig[0].GetFileName(), "testfile_1.yml")
+		assert.True(t, rc.FileIgnoreConfig[0].ChecksumMatches("file1_checksum"))
+		assert.Equal(t, rc.FileIgnoreConfig[1].GetFileName(), "testfile_2.yml")
+		assert.True(t, rc.FileIgnoreConfig[1].ChecksumMatches("file2_checksum"))
+		assert.Equal(t, rc.FileIgnoreConfig[2].GetFileName(), "testfile_3.yml")
+		assert.True(t, rc.FileIgnoreConfig[2].ChecksumMatches("file3_checksum"))
 
 		setRepoFileReader(defaultRepoFileReader)
 	})

--- a/talismanrc/rc_file_test.go
+++ b/talismanrc/rc_file_test.go
@@ -36,7 +36,7 @@ func TestShouldIgnoreUnformattedFiles(t *testing.T) {
 		})
 
 		talismanRC, _ := Load()
-		assert.True(t, talismanRC.AcceptsAll(), "Expected commented line '%s' to result in no ignore patterns", s)
+		assert.Equal(t, &TalismanRC{Version: "1.0"}, talismanRC, "Expected commented line '%s' to result in an empty TalismanRC")
 	}
 	setRepoFileReader(defaultRepoFileReader)
 }

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -31,8 +31,8 @@ type persistedRC struct {
 	CustomSeverities []CustomSeverityConfig `yaml:"custom_severities,omitempty"`
 	AllowedPatterns  []string               `yaml:"allowed_patterns,omitempty"`
 	Experimental     ExperimentalConfig     `yaml:"experimental,omitempty"`
-	Threshold        severity.Severity      `default:"low" yaml:"threshold,omitempty"`
-	Version          string                 `default:"2.0" yaml:"version"`
+	Threshold        severity.Severity      `yaml:"threshold,omitempty"`
+	Version          string                 `yaml:"version"`
 }
 
 // SuggestRCFor returns the talismanRC file content corresponding to input ignore configs

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -18,7 +18,7 @@ type TalismanRC struct {
 	ScopeConfig      []ScopeConfig          `yaml:"-"`
 	CustomPatterns   []PatternString        `yaml:"-"`
 	CustomSeverities []CustomSeverityConfig `yaml:"-"`
-	AllowedPatterns  []*regexp.Regexp       `yaml:"-"`
+	AllowedPatterns  []*Pattern             `yaml:"-"`
 	Experimental     ExperimentalConfig     `yaml:"-"`
 	Threshold        severity.Severity      `yaml:"-"`
 	Version          string                 `yaml:"version"`
@@ -180,9 +180,9 @@ func fromPersistedRC(configFromTalismanRCFile *persistedRC) *TalismanRC {
 	tRC.Experimental = configFromTalismanRCFile.Experimental
 	tRC.CustomPatterns = configFromTalismanRCFile.CustomPatterns
 	tRC.CustomSeverities = configFromTalismanRCFile.CustomSeverities
-	tRC.AllowedPatterns = make([]*regexp.Regexp, len(configFromTalismanRCFile.AllowedPatterns))
+	tRC.AllowedPatterns = make([]*Pattern, len(configFromTalismanRCFile.AllowedPatterns))
 	for i, p := range configFromTalismanRCFile.AllowedPatterns {
-		tRC.AllowedPatterns[i] = regexp.MustCompile(p)
+		tRC.AllowedPatterns[i] = &Pattern{regexp.MustCompile(p)}
 	}
 
 	tRC.FileIgnoreConfig = configFromTalismanRCFile.FileIgnoreConfig

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -14,13 +14,14 @@ import (
 )
 
 type TalismanRC struct {
-	FileIgnoreConfig []FileIgnoreConfig     `yaml:"-"`
+	FileIgnoreConfig []FileIgnoreConfig     `yaml:"fileignoreconfig,omitempty"`
 	ScopeConfig      []ScopeConfig          `yaml:"-"`
 	CustomPatterns   []PatternString        `yaml:"-"`
 	CustomSeverities []CustomSeverityConfig `yaml:"-"`
 	AllowedPatterns  []*regexp.Regexp       `yaml:"-"`
 	Experimental     ExperimentalConfig     `yaml:"-"`
 	Threshold        severity.Severity      `yaml:"-"`
+	Version          string                 `yaml:"version"`
 	base             *persistedRC
 }
 
@@ -37,8 +38,8 @@ type persistedRC struct {
 
 // SuggestRCFor returns the talismanRC file content corresponding to input ignore configs
 func SuggestRCFor(configs []FileIgnoreConfig) string {
-	pRC := persistedRC{FileIgnoreConfig: configs}
-	result, _ := yaml.Marshal(pRC)
+	tRC := TalismanRC{FileIgnoreConfig: configs, Version: DefaultRCVersion}
+	result, _ := yaml.Marshal(tRC)
 
 	return string(result)
 }
@@ -199,8 +200,4 @@ func Load() (*TalismanRC, error) {
 
 func ConfigFromFile() (*persistedRC, error) {
 	return readConfigFromRCFile(repoFileReader())
-}
-
-func MakeWithFileIgnores(fileIgnoreConfigs []FileIgnoreConfig) *persistedRC {
-	return &persistedRC{FileIgnoreConfig: fileIgnoreConfigs, Version: DefaultRCVersion}
 }

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -49,11 +49,10 @@ custom_severities:
 - detector: Base64Content
   severity: low
 `)
-	persistedRC, _ := newPersistedRC(talismanRCContents)
-	talismanRC := fromPersistedRC(persistedRC)
-	assert.Equal(t, persistedRC.Threshold, severity.High)
-	assert.Equal(t, len(persistedRC.CustomSeverities), 1)
-	assert.Equal(t, persistedRC.CustomSeverities, talismanRC.CustomSeverities)
+	talismanRC, _ := newPersistedRC(talismanRCContents)
+	assert.Equal(t, talismanRC.Threshold, severity.High)
+	assert.Equal(t, len(talismanRC.CustomSeverities), 1)
+	assert.Equal(t, talismanRC.CustomSeverities, []CustomSeverityConfig{{Detector: "Base64Content", Severity: severity.Low}})
 }
 
 func TestDirectoryPatterns(t *testing.T) {

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -117,13 +117,6 @@ func TestIgnoringDetectors(t *testing.T) {
 	assertAcceptsDetector("foo", "someDetector", "foo", "someOtherDetector", t)
 }
 
-func TestMakeWithFileIgnores(t *testing.T) {
-	ignoreConfigs := []FileIgnoreConfig{}
-	builtConfig := MakeWithFileIgnores(ignoreConfigs)
-	assert.Equal(t, builtConfig.FileIgnoreConfig, []FileIgnoreConfig{})
-	assert.Equal(t, builtConfig.Version, DefaultRCVersion)
-}
-
 func TestAddIgnoreFilesInHookMode(t *testing.T) {
 	ignoreConfig := FileIgnoreConfig{
 		FileName:        "Foo",
@@ -228,7 +221,7 @@ func TestSuggestRCFor(t *testing.T) {
 		expectedRC := `fileignoreconfig:
 - filename: some_filename
   checksum: some_checksum
-version: ""
+version: "1.0"
 `
 		str := SuggestRCFor(fileIgnoreConfigs)
 		assert.Equal(t, expectedRC, str)
@@ -244,7 +237,7 @@ version: ""
 		expectedRC := `fileignoreconfig:
 - filename: some_filename
   checksum: some_checksum
-version: ""
+version: "1.0"
 `
 		str := SuggestRCFor(fileIgnoreConfigs)
 		assert.Equal(t, expectedRC, str)

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -22,7 +22,7 @@ func TestShouldFilterAllowedPatternsFromAddition(t *testing.T) {
 	const hex string = "68656C6C6F20776F726C6421"
 	const fileContent string = "Prefix content" + hex
 	gitRepoAddition1 := testAdditionWithData("file1", []byte(fileContent))
-	talismanrc := &TalismanRC{AllowedPatterns: []*regexp.Regexp{regexp.MustCompile(hex)}}
+	talismanrc := &TalismanRC{AllowedPatterns: []*Pattern{{regexp.MustCompile(hex)}}}
 
 	fileContentFiltered := talismanrc.FilterAllowedPatternsFromAddition(gitRepoAddition1)
 

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -120,24 +120,19 @@ func TestIgnoringDetectors(t *testing.T) {
 func TestMakeWithFileIgnores(t *testing.T) {
 	ignoreConfigs := []FileIgnoreConfig{}
 	builtConfig := MakeWithFileIgnores(ignoreConfigs)
-	assert.Equal(t, builtConfig.FileIgnoreConfig, ignoreConfigs)
+	assert.Equal(t, builtConfig.FileIgnoreConfig, []FileIgnoreConfig{})
 	assert.Equal(t, builtConfig.Version, DefaultRCVersion)
 }
 
-func TestBuildIgnoreConfig(t *testing.T) {
-	ignoreConfig := BuildIgnoreConfig("filename", "asdfasdfasdfasdfasdf", nil)
-	assert.IsType(t, &FileIgnoreConfig{}, ignoreConfig)
-}
-
 func TestAddIgnoreFilesInHookMode(t *testing.T) {
-	ignoreConfig := &FileIgnoreConfig{
+	ignoreConfig := FileIgnoreConfig{
 		FileName:        "Foo",
 		Checksum:        "SomeCheckSum",
 		IgnoreDetectors: []string{},
 		AllowedPatterns: []string{}}
 	os.Remove(DefaultRCFileName)
 	talismanRCConfig := createTalismanRCWithScopeIgnores([]string{})
-	talismanRCConfig.base.AddIgnores([]IgnoreConfig{ignoreConfig})
+	talismanRCConfig.base.AddIgnores([]FileIgnoreConfig{ignoreConfig})
 	talismanRCConfigFromFile, _ := ConfigFromFile()
 	assert.Equal(t, 1, len(talismanRCConfigFromFile.FileIgnoreConfig))
 	os.Remove(DefaultRCFileName)
@@ -168,7 +163,7 @@ func testAdditionWithData(path string, content []byte) gitrepo.Addition {
 }
 
 func createTalismanRCWithFileIgnores(filename string, detector string, allowedPatterns []string) *TalismanRC {
-	fileIgnoreConfig := &FileIgnoreConfig{}
+	fileIgnoreConfig := FileIgnoreConfig{}
 	fileIgnoreConfig.FileName = filename
 	if detector != "" {
 		fileIgnoreConfig.IgnoreDetectors = []string{detector}
@@ -177,7 +172,7 @@ func createTalismanRCWithFileIgnores(filename string, detector string, allowedPa
 		fileIgnoreConfig.AllowedPatterns = allowedPatterns
 	}
 
-	return &TalismanRC{IgnoreConfigs: []IgnoreConfig{fileIgnoreConfig}}
+	return &TalismanRC{FileIgnoreConfig: []FileIgnoreConfig{fileIgnoreConfig}}
 }
 
 func createTalismanRCWithScopeIgnores(scopesToIgnore []string) *TalismanRC {
@@ -224,8 +219,8 @@ func TestFileIgnoreConfig_GetAllowedPatterns(t *testing.T) {
 
 func TestSuggestRCFor(t *testing.T) {
 	t.Run("should suggest proper RC when ignore configs are valid", func(t *testing.T) {
-		fileIgnoreConfigs := []IgnoreConfig{
-			&FileIgnoreConfig{
+		fileIgnoreConfigs := []FileIgnoreConfig{
+			{
 				FileName: "some_filename",
 				Checksum: "some_checksum",
 			},
@@ -240,8 +235,8 @@ version: ""
 	})
 
 	t.Run("should ignore invalid configs", func(t *testing.T) {
-		fileIgnoreConfigs := []IgnoreConfig{
-			&FileIgnoreConfig{
+		fileIgnoreConfigs := []FileIgnoreConfig{
+			{
 				FileName: "some_filename",
 				Checksum: "some_checksum",
 			},

--- a/talismanrc/types.go
+++ b/talismanrc/types.go
@@ -12,13 +12,6 @@ type CustomSeverityConfig struct {
 	Severity severity.Severity `yaml:"severity"`
 }
 
-type IgnoreConfig interface {
-	isEffective(string) bool
-	GetFileName() string
-	GetAllowedPatterns() []*regexp.Regexp
-	ChecksumMatches(checksum string) bool
-}
-
 type FileIgnoreConfig struct {
 	FileName        string   `yaml:"filename"`
 	Checksum        string   `yaml:"checksum,omitempty"`
@@ -49,6 +42,10 @@ func (i *FileIgnoreConfig) GetAllowedPatterns() []*regexp.Regexp {
 		}
 	}
 	return i.compiledPatterns
+}
+
+func IgnoreFileWithChecksum(filename, checksum string) FileIgnoreConfig {
+	return FileIgnoreConfig{FileName: filename, Checksum: checksum}
 }
 
 type ScopeConfig struct {

--- a/talismanrc/types.go
+++ b/talismanrc/types.go
@@ -3,9 +3,30 @@ package talismanrc
 import (
 	"regexp"
 	"talisman/detector/severity"
+
+	logr "github.com/sirupsen/logrus"
 )
 
 type PatternString string
+
+type Pattern struct {
+	*regexp.Regexp
+}
+
+func (p Pattern) MarshalYAML() (interface{}, error) {
+	return p.String(), nil
+}
+
+func (p *Pattern) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	err := unmarshal(&s)
+	if err != nil {
+		logr.Errorf("Pattern.UmarshalYAML error: %v", err)
+		return err
+	}
+	*p = Pattern{regexp.MustCompile(s)}
+	return nil
+}
 
 type CustomSeverityConfig struct {
 	Detector string            `yaml:"detector"`

--- a/talismanrc/types_test.go
+++ b/talismanrc/types_test.go
@@ -1,0 +1,33 @@
+package talismanrc
+
+import (
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	logr "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func init() {
+	logr.SetOutput(io.Discard)
+}
+
+func TestCustomMarshalling(t *testing.T) {
+	t.Run("Can unmarshal yaml into a Pattern struct", func(t *testing.T) {
+		savedPattern := []byte("text-pattern")
+		fromText := Pattern{}
+		err := yaml.Unmarshal(savedPattern, &fromText)
+		assert.Nil(t, err, "Should have unmarshalled %s into a Pattern", savedPattern)
+		assert.Equal(t, Pattern{regexp.MustCompile(string(savedPattern))}, fromText)
+	})
+
+	t.Run("Can marshal a Pattern struct into yaml", func(t *testing.T) {
+		pattern := Pattern{regexp.MustCompile("pattern")}
+		str, err := yaml.Marshal(pattern)
+		assert.Nil(t, err, "Should have marshalled %v into a string of yaml", pattern)
+		assert.Equal(t, pattern.String(), strings.TrimSpace(string(str)))
+	})
+}


### PR DESCRIPTION
After #471, we no longer need complex logic when generating a TalismanRC struct from a .talismanrc file. This simplifies loading from and writing to a .talismanrc file by directly unmarshalling/marshalling TalismanRC, instead of using the persistedRC struct as an intermediate.