### PR TITLE
Ignore scoped files anywhere in repo

### DIFF
--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -1,7 +1,7 @@
 package talismanrc
 
 var knownScopes = map[string][]string{
-	"node":      {"pnpm-lock.yaml", "yarn.lock", "package-lock.json", "node_modules/"},
+	"node":      {"pnpm-lock.yaml", "yarn.lock", "package-lock.json"},
 	"go":        {"makefile", "go.mod", "go.sum", "Gopkg.toml", "Gopkg.lock", "glide.yaml", "glide.lock"},
 	"images":    {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 	"bazel":     {"*.bzl"},

--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -1,11 +1,12 @@
 package talismanrc
 
+// Mapping of language scopes to names of files that should be ignored anywhere in a repository
 var knownScopes = map[string][]string{
 	"node":      {"pnpm-lock.yaml", "yarn.lock", "package-lock.json"},
 	"go":        {"makefile", "go.mod", "go.sum", "Gopkg.toml", "Gopkg.lock", "glide.yaml", "glide.lock"},
 	"images":    {"*.jpeg", "*.jpg", "*.png", "*.tiff", "*.bmp"},
 	"bazel":     {"*.bzl"},
-	"terraform": {".terraform.lock.hcl", "*.terraform.lock.hcl"},
+	"terraform": {".terraform.lock.hcl"},
 	"php":       {"composer.lock"},
 	"python":    {"poetry.lock", "Pipfile.lock", "requirements.txt"},
 }

--- a/talismanrc/talismanrc.go
+++ b/talismanrc/talismanrc.go
@@ -44,7 +44,7 @@ func (tRC *TalismanRC) RemoveScopedFiles(additions []gitrepo.Addition) []gitrepo
 	for _, addition := range additions {
 		isFilePresentInScope := false
 		for _, fileName := range applicableScopeFileNames {
-			if addition.Matches(fileName) {
+			if addition.NameMatches(fileName) {
 				isFilePresentInScope = true
 				break
 			}

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -90,13 +90,19 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 		"node": {
 			testAddition("yarn.lock"),
 			testAddition("pnpm-lock.yaml"),
-			testAddition("package-lock.json")},
+			testAddition("package-lock.json"),
+		},
 		"go": {
 			testAddition("Gopkg.lock"),
 			testAddition("makefile"),
-			testAddition("go.mod"), testAddition("go.sum"),
-			testAddition("Gopkg.toml"), testAddition("Gopkg.lock"),
-			testAddition("glide.yaml"), testAddition("glide.lock"),
+			testAddition("go.mod"),
+			testAddition("go.sum"),
+			testAddition("submodule/go.mod"),
+			testAddition("submodule/go.sum"),
+			testAddition("Gopkg.toml"),
+			testAddition("Gopkg.lock"),
+			testAddition("glide.yaml"),
+			testAddition("glide.lock"),
 		},
 		"images": {
 			testAddition("img.jpeg"),
@@ -105,7 +111,9 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 			testAddition("img.tiff"),
 			testAddition("img.bmp"),
 		},
-		"bazel": {testAddition("bazelfile.bzl")},
+		"bazel": {
+			testAddition("bazelfile.bzl"),
+		},
 		"terraform": {
 			testAddition(".terraform.lock.hcl"),
 			testAddition("foo/.terraform.lock.hcl"),

--- a/talismanrc/talismanrc_test.go
+++ b/talismanrc/talismanrc_test.go
@@ -90,8 +90,7 @@ func TestIgnoreAdditionsByScope(t *testing.T) {
 		"node": {
 			testAddition("yarn.lock"),
 			testAddition("pnpm-lock.yaml"),
-			testAddition("package-lock.json"),
-			testAddition("node_modules/module1/foo.js")},
+			testAddition("package-lock.json")},
 		"go": {
 			testAddition("Gopkg.lock"),
 			testAddition("makefile"),


### PR DESCRIPTION
Unlike custom fileignores in .talismanrc, all file names ignored by scope configs should be ignored regardless of relative path within repo

Fixes #476