### PR TITLE
chore: support go1.24 build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-go 1.18
+go 1.23.0
+
+toolchain go1.24.2


### PR DESCRIPTION
seeing some build issue against go 1.24.2 for the recent two releases, thus updating the go.mod

```
   go: updates to go.mod needed; to update it:
  	go mod tidy
```

- https://github.com/Homebrew/homebrew-core/pull/220513
- https://github.com/Homebrew/homebrew-core/pull/220882