### PR TITLE
Add uv.lock to python known scopes

### DIFF
--- a/talismanrc/scopes.go
+++ b/talismanrc/scopes.go
@@ -8,5 +8,5 @@ var knownScopes = map[string][]string{
 	"bazel":     {"*.bzl"},
 	"terraform": {".terraform.lock.hcl"},
 	"php":       {"composer.lock"},
-	"python":    {"poetry.lock", "Pipfile.lock", "requirements.txt"},
+	"python":    {"poetry.lock", "Pipfile.lock", "requirements.txt", "uv.lock"},
 }


### PR DESCRIPTION
Adds uv's `uv.lock` lockfile to the default python known scopes.